### PR TITLE
Add pdm scripts for server dev

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -2,6 +2,52 @@
 
 This is a Django based API running GraphQL.
 
+## Running the server
+
+### Creating credentials
+
+The server needs a database, and both need credentials so they can talk. Let's get that out of the way first.
+Create some database credentials like so:
+```sh
+cat <<-'EOF' > postgres.env
+POSTGRES_USER=cpho_user-admin
+POSTGRES_PASSWORD=123
+POSTGRES_DB=cpho_dev
+EOF
+```
+And we'll need some matching credentials for the server itself:
+```sh
+cat <<-'EOF' > server.env
+DEBUG=True
+ALLOWED_HOSTS=localhost,127.0.0.1
+DB_NAME=cpho_dev
+DB_USER=cpho_user-admin
+DB_PASSWORD=123
+DB_HOST=localhost
+DB_PORT=5432
+SECRET_KEY= # ADD GENERATED KEY HERE #
+# PGADMIN CONTAINER
+PGADMIN_DEFAULT_EMAIL=admin@example.com
+PGADMIN_DEFAULT_PASSWORD=123
+PGADMIN_LISTEN_PORT=5433
+PGADMIN_CONFIG_SERVER_MODE=False
+PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED=False
+PGADMIN_CONFIG_UPGRADE_CHECK_ENABLED=False
+EOF
+```
+
+### Start the server
+
+Assuming docker is installed, you can start postgres locally and run the migrations with the following command:
+
+```sh
+pdm dev
+```
+
+That script is a composite that runs `pdm db` then `pdm wait` to give it time to start, and follows that with `pdm migrate` and finally `pdm start`.
+You can use them all separately if you like, and `pdm stop` is there when you're done.
+
+
 ## Managing dependencies
 
 Dependencies are managed with [PDM](https://pdm.fming.dev/latest/). Mostly this will boil down to adding deps with `pdm add newdep`.

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -5,6 +5,8 @@ description = ""
 authors = [
     {name = "Eduardo Szeckir", email = "eduardo.szeckir@phac-aspc.gc.ca"},
 ]
+requires-python = ">=3.8"
+license = {text = "MIT"}
 dependencies = [
     "aniso8601==9.0.1",
     "asgiref==3.5.2",
@@ -30,8 +32,6 @@ dependencies = [
     "tzdata==2022.5",
     "colorama>=0.4.6",
 ]
-requires-python = ">=3.8"
-license = {text = "MIT"}
 [project.optional-dependencies]
 
 [tool.pdm]
@@ -43,3 +43,13 @@ dev = [
 [build-system]
 requires = ["pdm-pep517>=1.0.0"]
 build-backend = "pdm.pep517.api"
+
+[tool.pdm.scripts]
+start.cmd = "python manage.py runserver localhost:8000"
+start.env_file = "server.env"
+migrate = "python manage.py migrate"
+db = "docker run --name pg -p 5432:5432 -d --env-file postgres.env postgres"
+wait ={shell = "sleep 1"}
+stop = {shell = "docker stop pg && docker rm pg"}
+dev = {composite = ["db", "wait", "migrate", "start"]}
+


### PR DESCRIPTION
This commit adds some helper scripts to make server developement nicer. Essentially `pdm db`, `pdm migrate` and `pdm start` all do roughly what you might expect, with the twist that the database is running postgres locally with docker. When you want to shut it down you can run `pdm stop`.

This uses 2 env files... `server.env` for the server and `postgres.env` for the database. Details are in the README.