### PR TITLE
Add api route to envoy proxy config

### DIFF
--- a/envoy.yaml
+++ b/envoy.yaml
@@ -27,6 +27,8 @@ static_resources:
                 route: { cluster: server }
               - match: { prefix: "/graphql" }
                 route: { cluster: server }
+              - match: { prefix: "/api" }
+                route: { cluster: server }
               - match: { prefix: "/" }
                 route: { cluster: frontend }
   clusters:


### PR DESCRIPTION
This commit ensures that paths prefixed with /api are forwarded to the server.