### PR TITLE
Fix local run

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,2 +1,3 @@
 build
 node_modules
+*.env

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,16 @@
 This project was bootstrapped with
 [Create React App](https://github.com/facebook/create-react-app).
 
+## Set environment variables
+
+Create a `.env` file so that the app can connect to the right server:
+
+```sh
+cat <<-'EOF' > .env
+REACT_APP_METHOD=local
+EOF
+```
+
 ## Available Scripts
 
 In the project directory, you can run `npm i` to install the dependencies and `npm start` to start the application in dev mode.

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -7,7 +7,10 @@ import * as serviceWorker from "./serviceWorker";
 import { ApolloClient, InMemoryCache, ApolloProvider } from "@apollo/client";
 
 const client = new ApolloClient({
-  uri: '/graphql',
+  uri:
+    process.env.REACT_APP_METHOD === "local"
+      ? "http://localhost:8000/graphql"
+      : "/graphql",
   cache: new InMemoryCache({
     addTypename: false,
   }),


### PR DESCRIPTION
This PR fixes the ability to run both the frontend and backend locally (without Docker).
Since the Docker container assumes both services in the same port, the uri for the GraphQL client needs to be adjusted to account for the local run.