### PR TITLE
Add .vscode/launch.json for VSCode debugging shortcuts

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+"version": "0.2.0",
+  "configurations": [
+    {
+      "name": "runserver",
+      "type": "python",
+      "request": "launch",
+      "program": "${workspaceFolder}/server/manage.py",
+      "cwd": "${workspaceFolder}/server",
+      "args": [
+        "runserver"
+      ],
+      "django": true,
+      "justMyCode": true
+    },
+    {
+      "name": "test",
+      "type": "python",
+      "request": "launch",
+      "program": "${workspaceFolder}/server/manage.py",
+      "cwd": "${workspaceFolder}/server",
+      "args": [
+        "test"
+      ],
+      "django": true,
+      "justMyCode": true
+    }
+  ]
+}


### PR DESCRIPTION
Adds `runserver` and `test` items to the VSCode debugging menu. I always find this useful on django projects, maybe worth doing on other projects and in the template repo (unless y'all really prefer debugging outside of VSCode).

![image](https://github.com/PHACDataHub/cpho-phase2/assets/11301919/326a13e4-d1e8-40ba-8836-a926b469f869)
