### PR TITLE
Fix IndicatorDatumFactory (SubFactory returned from LazyAttribute)

### DIFF
--- a/server/cpho/model_factories.py
+++ b/server/cpho/model_factories.py
@@ -61,10 +61,10 @@ class IndicatorDatumFactory(factory.django.DjangoModelFactory):
     indicator = factory.SubFactory(IndicatorFactory)
     period = factory.SubFactory(PeriodFactory)
     dimension_type = factory.SubFactory(DimensionTypeFactory)
-    dimension_value = factory.LazyAttribute(
-        lambda o: factory.SubFactory(DimensionValueFactory)
-        if not o.dimension_type.is_literal
-        else None
+    dimension_value = factory.Maybe(
+        "dimension_type.is_literal",
+        yes_declaration=None,
+        no_declaration=factory.SubFactory(DimensionValueFactory),
     )
     value = factory.Faker("pyfloat")
     data_quality = factory.LazyFunction(


### PR DESCRIPTION
Fixes `IndicatorDatumFactory`, indirectly fixes `test_indicators_are_versioned`, which was failing with:
> ValueError: Cannot assign "<factory.declarations.SubFactory object at 0x7fa69a23d000>": "IndicatorDatum.dimension_value" must be a "DimensionValue" instance."

Seems `SubFactory` objects have an `evaluate` method that needs to be called (with the right context args, this is a Factory Boy `Declaration` class concept) to instantiate them, but this seems to not be handled when it is returned from a `LazyAttribute`. `Maybe` is an alternative to `LazyAttribute` that is less flexible but is evaluated differently... and just so happens to properly handle the evaluation of returned `Declaration` type classes... yeah, this is annoying, had to crack open the Factory Boy source code to get any clue what was going on, and I still don't see _why_ this isn't consistent. Not documented, but I guess they only intend `LazyAttribute` to be used for attributes :shrug:  

Maybe a gotcha to document somewhere, this could reoccur on any of our Django projects using Factory Boy.