### PR TITLE
Pattern for more safely using sensitive/secret config values in dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 # Django
 **/staticfiles
 
-# environment variables (only allow .env.dev, no other env files)
+# environment variables (only allow .env.dev-public, no other env files)
 **/.env*
 !**/.env.dev-public
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 
 # environment variables (only allow .env.dev, no other env files)
 **/.env*
-!**/.env.dev
+!**/.env.dev-public
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and PDM
 **/__pypackages__/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,7 +32,8 @@
     },
     "files.insertFinalNewline": true,
     "[python]": {
-      "editor.defaultFormatter": "ms-python.black-formatter"
+      "editor.defaultFormatter": "ms-python.black-formatter",
+      "editor.tabSize": 4
     },
   }
   

--- a/server/.env.dev-public
+++ b/server/.env.dev-public
@@ -22,7 +22,7 @@ IS_LOCAL_DEV=True
 ENABLE_DEBUG_TOOLBAR=True
 INTERNAL_IPS=127.0.0.1
 
-# use to test prod-like whitenoise configuration; requires collectstatic output!
+# Use to test prod-like whitenoise configuration; requires collectstatic output!
 FORCE_WHITENOISE_PROD_BEHAVIOUR=False
 
 # this is to disable session timeout

--- a/server/.env.dev-public
+++ b/server/.env.dev-public
@@ -1,3 +1,9 @@
+# NO SECRET VALUES, just dev config and place holders
+
+# If you ever DO need to use a sensitive/secret .env value in dev, put it in .env.dev-secret.
+# Note that .env.dev-secret will not exist when CI/CD runs your tests, your tests should never depend on 
+# secret values (e.g. instead of using a dev API key for a thrid-party service, mock the API for your tests)
+
 TEST_DB_NAME=cpho_test_db
 DB_NAME=cpho_dev_db
 DB_USER=cpho_db_user
@@ -16,7 +22,7 @@ IS_LOCAL_DEV=True
 ENABLE_DEBUG_TOOLBAR=True
 INTERNAL_IPS=127.0.0.1
 
-# Use to test prod-like whitenoise configuration; requires collectstatic output!
+# use to test prod-like whitenoise configuration; requires collectstatic output!
 FORCE_WHITENOISE_PROD_BEHAVIOUR=False
 
 # this is to disable session timeout

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 from django.urls import reverse_lazy
 
-from decouple import Config, Csv, RepositoryEnv
+from decouple import Config, Csv, RepositoryEnv, undefined
 from phac_aspc.django.settings import *
 from phac_aspc.django.settings.utils import (
     configure_apps,
@@ -32,7 +32,18 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 try:
     config = Config(RepositoryEnv(os.path.join(BASE_DIR, ".env.prod")))
 except:
-    config = Config(RepositoryEnv(os.path.join(BASE_DIR, ".env.dev")))
+
+    def dev_config_merged(*args, default=undefined, **kwargs):
+        try:
+            return Config(
+                RepositoryEnv(os.path.join(BASE_DIR, ".env.dev-secret"))
+            )(*args, **kwargs)
+        except:
+            return Config(
+                RepositoryEnv(os.path.join(BASE_DIR, ".env.dev-public"))
+            )(*args, default, **kwargs)
+
+    config = dev_config_merged
 
 
 IS_LOCAL_DEV = config("IS_LOCAL_DEV", cast=bool, default=False)

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -30,7 +30,6 @@ from server.settings_util import get_project_config
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
-# Reminder: decouple config(...) looks in OS env vars first, configured .env file second
 config = get_project_config(BASE_DIR)
 
 

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -16,34 +16,22 @@ from pathlib import Path
 
 from django.urls import reverse_lazy
 
-from decouple import Config, Csv, RepositoryEnv, undefined
+from decouple import Csv
 from phac_aspc.django.settings import *
 from phac_aspc.django.settings.utils import (
     configure_apps,
     configure_middleware,
 )
 
+from server.settings_util import get_project_config
+
 # See https://docs.djangoproject.com/en/4.1/howto/deployment/checklist/
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-# Point decouple.Config to the appropriate .env file
+
 # Reminder: decouple config(...) looks in OS env vars first, configured .env file second
-try:
-    config = Config(RepositoryEnv(os.path.join(BASE_DIR, ".env.prod")))
-except:
-
-    def dev_config_merged(*args, default=undefined, **kwargs):
-        try:
-            return Config(
-                RepositoryEnv(os.path.join(BASE_DIR, ".env.dev-secret"))
-            )(*args, **kwargs)
-        except:
-            return Config(
-                RepositoryEnv(os.path.join(BASE_DIR, ".env.dev-public"))
-            )(*args, default, **kwargs)
-
-    config = dev_config_merged
+config = get_project_config(BASE_DIR)
 
 
 IS_LOCAL_DEV = config("IS_LOCAL_DEV", cast=bool, default=False)

--- a/server/server/settings_util.py
+++ b/server/server/settings_util.py
@@ -1,27 +1,37 @@
 import os
 
-from decouple import Config, RepositoryEnv, undefined
+from decouple import Config, RepositoryEnv, UndefinedValueError, undefined
 
 PROD_ENV_FILE_NAME = ".env.prod"
 DEV_PUBLIC_ENV_FILE_NAME = ".env.dev-public"
 DEV_SECRET_ENV_FILE_NAME = ".env.dev-secret"
 
 
+# Reminder: decouple config(...) looks in OS env vars first, configured env file second
 def get_project_config(BASE_DIR):
     try:
+        # If the prod env file exists, use it exclusively
         config = Config(
             RepositoryEnv(os.path.join(BASE_DIR, PROD_ENV_FILE_NAME))
         )
-    except:
+    except FileNotFoundError:
+        # If the prod env file doesn't exist
+        #   1) look for the secret in the dev-secret env file
+        #   2) if the dev-secret env file doesn't exist OR the the secret isn't
+        #      found in it, look in the dev-public file
+        #   3) if still not found, fall back to provided `default` (if any)
 
+        # IMPORTANT: dev_config_merged must support the API of decouple's config function! Masquerades as it in use
         def dev_config_merged(*args, default=undefined, **kwargs):
             try:
+                # Note that the `default` value is not propogated to the dev-secret call,
+                # else the default would be returned without looking in dev-public
                 return Config(
                     RepositoryEnv(
                         os.path.join(BASE_DIR, DEV_SECRET_ENV_FILE_NAME)
                     )
                 )(*args, **kwargs)
-            except:
+            except (FileNotFoundError, UndefinedValueError):
                 return Config(
                     RepositoryEnv(
                         os.path.join(BASE_DIR, DEV_PUBLIC_ENV_FILE_NAME)

--- a/server/server/settings_util.py
+++ b/server/server/settings_util.py
@@ -1,0 +1,33 @@
+import os
+
+from decouple import Config, RepositoryEnv, undefined
+
+PROD_ENV_FILE_NAME = ".env.prod"
+DEV_PUBLIC_ENV_FILE_NAME = ".env.dev-public"
+DEV_SECRET_ENV_FILE_NAME = ".env.dev-secret"
+
+
+def get_project_config(BASE_DIR):
+    try:
+        config = Config(
+            RepositoryEnv(os.path.join(BASE_DIR, PROD_ENV_FILE_NAME))
+        )
+    except:
+
+        def dev_config_merged(*args, default=undefined, **kwargs):
+            try:
+                return Config(
+                    RepositoryEnv(
+                        os.path.join(BASE_DIR, DEV_SECRET_ENV_FILE_NAME)
+                    )
+                )(*args, **kwargs)
+            except:
+                return Config(
+                    RepositoryEnv(
+                        os.path.join(BASE_DIR, DEV_PUBLIC_ENV_FILE_NAME)
+                    )
+                )(*args, default, **kwargs)
+
+        config = dev_config_merged
+
+    return config

--- a/server/tests/test_settings_util.py
+++ b/server/tests/test_settings_util.py
@@ -1,0 +1,73 @@
+import pytest
+from decouple import UndefinedValueError
+
+from server.settings_util import (
+    DEV_PUBLIC_ENV_FILE_NAME,
+    DEV_SECRET_ENV_FILE_NAME,
+    PROD_ENV_FILE_NAME,
+    get_project_config,
+)
+
+
+def write_env_file(temp_path, env_file_name):
+    env_file = temp_path / env_file_name
+
+    content = f"""
+    ENV_FILE_USED={env_file_name}
+    ENV_SPECIFIC_{env_file_name}=True
+    """
+
+    env_file.write_text(content)
+
+
+def test_get_project_config_uses_prod_exclusively_if_exists(tmp_path):
+    write_env_file(tmp_path, PROD_ENV_FILE_NAME)
+    write_env_file(tmp_path, DEV_PUBLIC_ENV_FILE_NAME)
+    write_env_file(tmp_path, DEV_SECRET_ENV_FILE_NAME)
+
+    config = get_project_config(BASE_DIR=tmp_path)
+
+    assert config("ENV_FILE_USED") == PROD_ENV_FILE_NAME
+
+    # assert that prod env is used exclusively, values from other env files undefined
+    with pytest.raises(UndefinedValueError):
+        config(f"ENV_SPECIFIC_{DEV_PUBLIC_ENV_FILE_NAME}")
+
+    assert (
+        config(
+            f"ENV_SPECIFIC_{DEV_PUBLIC_ENV_FILE_NAME}",
+            default="can_still_use_defaults",
+        )
+        == "can_still_use_defaults"
+    )
+
+
+def test_get_project_config_uses_merged_dev_envs_with_priority_for_dev_secret(
+    tmp_path,
+):
+    write_env_file(tmp_path, DEV_PUBLIC_ENV_FILE_NAME)
+    write_env_file(tmp_path, DEV_SECRET_ENV_FILE_NAME)
+
+    config = get_project_config(BASE_DIR=tmp_path)
+
+    # assert that priority is given to dev secrets
+    assert config("ENV_FILE_USED") == DEV_SECRET_ENV_FILE_NAME
+
+    # assert that contents are merged (can use values from both)
+    assert (
+        config(f"ENV_SPECIFIC_{DEV_SECRET_ENV_FILE_NAME}", cast=bool) == True
+    )
+    assert (
+        config(f"ENV_SPECIFIC_{DEV_PUBLIC_ENV_FILE_NAME}", cast=bool) == True
+    )
+
+    # assert that expected config behaviour still present (errors on undefined, defaults work)
+    with pytest.raises(UndefinedValueError):
+        config(f"not_real")
+    assert (
+        config(
+            "not_real",
+            default="can_still_use_defaults",
+        )
+        == "can_still_use_defaults"
+    )


### PR DESCRIPTION
As discussed in #50, there's good reason to commit a dev `.env`  to the repo (one less thing for each individual dev to manage/keep in sync, and needs to be available and in-sync for testing in CI too), but there's also a risk that dev's may at some point need to use a sensitive/secret env value for local testing. Committing the dev `.env` file makes it much more likely that such a value could be inadvertently committed in the future, which we do not want.

GitHub secret scanning and push protection are an incomplete mitigation, as they won't be able to detect all possible secret patterns. Better than nothing though.

I'm introducing a further convention here, where a git-ignored `.env.dev-secret` can be used if a dev ever needs to test with a secret value locally (e.g. an API key for a third party service, although even then it should be a temporary, non-prod, key). If present, the values from `.env.dev-secret` will be merged in (with priority over) `.env.dev-public` when accessed in `settings.py`.

This convention existing, and renaming  `.env.dev` to `.env.dev-public`, should make it even less likely for devs to slip up and leak a secret.