### PR TITLE
Upload test coverage reports

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -51,22 +51,22 @@ steps:
       source .env.cloud_build 
 
       echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
-      gsutil cp ./coverage/coverage.json gs://hopic-test-coverage-reports/$BRANCH/coverage-${COMMIT_SHA}.json
+      gsutil cp ./coverage/coverage.json "gs://hopic-test-coverage-reports/${BRANCH}/coverage-${COMMIT_SHA}.json"
       #:$BRANCH:$COMMIT_SHA:$(date +%s)
 
-    - id: "Tear down tests"
-    name: "gcr.io/cloud-builders/docker"
-    script: |
-      #!/usr/bin/env bash
-      set -o errexit
-      set -o pipefail
-      set -o nounset
+    # - id: "Tear down tests"
+    # name: "gcr.io/cloud-builders/docker"
+    # script: |
+    #   #!/usr/bin/env bash
+    #   set -o errexit
+    #   set -o pipefail
+    #   set -o nounset
       
-      # echo "Get cloud build project configuration values"
-      # source .env.cloud_build
+    #   # echo "Get cloud build project configuration values"
+    #   # source .env.cloud_build
 
-      # echo "Tear down containers and volumes"
-      docker compose -f docker-compose.run-tests.yaml down -v
+    #   # echo "Tear down containers and volumes"
+    #   docker compose -f docker-compose.run-tests.yaml down -v
 
   - id: "Build image if main"
     name: "gcr.io/cloud-builders/docker"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -31,8 +31,7 @@ steps:
       source .env.cloud_build
 
       echo "Build images for testing, run tests and create report"
-      echo "UID=$(id -u) GID=$(id -g)"
-      UID=$(id -u) GID=$(id -g) docker compose -f docker-compose.run-tests.yaml up --exit-code-from server && chown -R $USER /cpho/web/coverage
+      docker compose -f docker-compose.run-tests.yaml up --exit-code-from server && chown -R $USER /cpho/web/coverage
       
       # NOTE: Tests are run within docker compose. When "--exit-code-from" is used, and the build or a command fails, this flag will cause the step to fail.  
       # Test reports are generated twice:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -36,31 +36,34 @@ steps:
       docker compose -f docker-compose.run-tests.yaml up --exit-code-from server
       # NOTE: Tests are run within docker compose. When "--exit-code-from" is used, and the build or a command fails, this flag will cause the step to fail.
       
+      echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
+      cp .coverage/coverage.json gs://hopic-test-coverage-reports/deployment_test_coverage_report
+      
       echo "Tear down containers and volumes"
       docker compose -f docker-compose.run-tests.yaml down -v
 
-  - id: "Upload test coverage reports to Google Cloud Storage"
-    name: 'gcr.io/cloud-builders/gsutil'
-    script: |
-      #!/usr/bin/env bash
-      set -o errexit
-      set -o pipefail
-      set -o nounset
+  # - id: "Upload test coverage reports to Google Cloud Storage"
+  #   name: 'gcr.io/cloud-builders/gsutil'
+  #   script: |
+  #     #!/usr/bin/env bash
+  #     set -o errexit
+  #     set -o pipefail
+  #     set -o nounset
       
-      echo "Get cloud build project configuration values"
-      source .env.cloud_build
+  #     echo "Get cloud build project configuration values"
+  #     source .env.cloud_build
 
-      echo "pwd is ${PWD}"
-      cbfilenames=`ls ./coverage`
-      for eachfile in $cbfilenames
-      do
-        echo $eachfile
-      done
+  #     echo "pwd is ${PWD}"
+  #     cbfilenames=`ls ./coverage`
+  #     for eachfile in $cbfilenames
+  #     do
+  #       echo $eachfile
+  #     done
 
-      echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
-      # echo "deployment_test_coverage_report:$BRANCH:$COMMIT_SHA:$(date +%s)""
-      cp .coverage/coverage.json gs://hopic-test-coverage-reports/deployment_test_coverage_report
-      #:$BRANCH:$COMMIT_SHA:$(date +%s)
+  #     echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
+  #     # echo "deployment_test_coverage_report:$BRANCH:$COMMIT_SHA:$(date +%s)""
+  #     cp .coverage/coverage.json gs://hopic-test-coverage-reports/deployment_test_coverage_report
+  #     #:$BRANCH:$COMMIT_SHA:$(date +%s)
 
   - id: "Build image if main"
     name: "gcr.io/cloud-builders/docker"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -52,7 +52,7 @@ steps:
 
       echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
       # echo "deployment_test_coverage_report:$BRANCH:$COMMIT_SHA:$(date +%s)""
-      cp ./coverage.json gs://hopic-test-coverage-reports/deployment_test_coverage_report
+      cp .coverage/coverage.json gs://hopic-test-coverage-reports/deployment_test_coverage_report
       #:$BRANCH:$COMMIT_SHA:$(date +%s)
 
   - id: "Build image if main"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -48,7 +48,7 @@ steps:
       set -o nounset
       
       echo "Get cloud build project configuration values"
-      source .env.cloud_build
+      source .env.cloud_build 
 
       echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
       gsutil cp ./coverage/coverage.json gs://hopic-test-coverage-reports/${BRANCH}/coverage:${COMMIT_SHA}.json

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -31,13 +31,8 @@ steps:
       source .env.cloud_build
 
       echo "Build images for testing, run tests and create report"
-      # TODO: Upload coverage report to somewhere like Google Cloud Storage, and determine how to more easily access results - currently we need to dig through the Cloud Build logs in order to view the report.  
-      # docker compose -f docker-compose.run-tests.yaml build --no-cache
       docker compose -f docker-compose.run-tests.yaml up --exit-code-from server
       # NOTE: Tests are run within docker compose. When "--exit-code-from" is used, and the build or a command fails, this flag will cause the step to fail.  
-      
-      # echo "Tear down containers and volumes"
-      # docker compose -f docker-compose.run-tests.yaml down -v
 
   - id: "Upload test coverage reports to Google Cloud Storage"
     name: 'gcr.io/cloud-builders/gsutil'
@@ -51,22 +46,18 @@ steps:
       source .env.cloud_build 
 
       echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
-      gsutil cp ./coverage/coverage.json "gs://hopic-test-coverage-reports/${BRANCH_NAME}/coverage-${COMMIT_SHA}.json"
-      #:$BRANCH:$COMMIT_SHA:$(date +%s)
+      gsutil cp ./coverage/coverage.json "gs://hopic-test-coverage-reports/${BRANCH_NAME}/$(date +%s)-${COMMIT_SHA}.json"
 
-    # - id: "Tear down tests"
-    # name: "gcr.io/cloud-builders/docker"
-    # script: |
-    #   #!/usr/bin/env bash
-    #   set -o errexit
-    #   set -o pipefail
-    #   set -o nounset
-      
-    #   # echo "Get cloud build project configuration values"
-    #   # source .env.cloud_build
+    - id: "Tear down tests"
+    name: "gcr.io/cloud-builders/docker"
+    script: |
+      #!/usr/bin/env bash
+      set -o errexit
+      set -o pipefail
+      set -o nounset
 
-    #   # echo "Tear down containers and volumes"
-    #   docker compose -f docker-compose.run-tests.yaml down -v
+      # echo "Tear down containers and volumes"
+      docker compose -f docker-compose.run-tests.yaml down -v
 
   - id: "Build image if main"
     name: "gcr.io/cloud-builders/docker"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -34,7 +34,7 @@ steps:
       docker compose -f docker-compose.run-tests.yaml up --exit-code-from server
       
       # NOTE: Tests are run within docker compose. When "--exit-code-from" is used, and the build or a command fails, this flag will cause the step to fail.  
-      # Test reports are generated twice:
+      # Test coverage reports are generated twice:
         # 1 - to terminal to be printed in Cloud Build Logs
         # 2 - to coverage.json in mounted volume.
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -38,7 +38,7 @@ steps:
       
       echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
       # cp ./coverage/coverage.json gs://hopic-test-coverage-reports/deployment_test_coverage_report
-      cp ./coverage/coverage.json gs://hopic-test-coverage-reports/coverage.json
+      gsutil cp ./coverage/coverage.json gs://hopic-test-coverage-reports/coverage.json
       
       echo "Tear down containers and volumes"
       docker compose -f docker-compose.run-tests.yaml down -v

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -51,9 +51,22 @@ steps:
       source .env.cloud_build
 
       echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
-      # echo "deployment_test_coverage_report:$BRANCH:$COMMIT_SHA:$(date +%s)""
-      gsutil cp ./coverage/coverage.json gs://hopic-test-coverage-reports/coverage.json
+      gsutil cp ./coverage/coverage.json gs://hopic-test-coverage-reports/${BRANCH}/coverage:${COMMIT_SHA}.json
       #:$BRANCH:$COMMIT_SHA:$(date +%s)
+
+    - id: "Tear down tests"
+    name: "gcr.io/cloud-builders/docker"
+    script: |
+      #!/usr/bin/env bash
+      set -o errexit
+      set -o pipefail
+      set -o nounset
+      
+      # echo "Get cloud build project configuration values"
+      # source .env.cloud_build
+
+      # echo "Tear down containers and volumes"
+      docker compose -f docker-compose.run-tests.yaml down -v
 
   - id: "Build image if main"
     name: "gcr.io/cloud-builders/docker"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -37,39 +37,38 @@ steps:
   - id: "Upload test coverage reports to Google Cloud Storage"
     name: 'gcr.io/cloud-builders/gsutil'
     entrypoint: "bash"
-    args:
-      - "-c"
-      - |
-        echo "Get cloud build project configuration values"
-        source .env.cloud_build
+  #   args:
+  #     - "-c"
+  #     - |
+  #       echo "Get cloud build project configuration values"
+  #       source .env.cloud_build
 
-        echo "Copy test coverage report from docker compose volume to Google Cloud Storage."
-        timestamp=$(date +%s)
-        gsutil cp ./coverage/coverage.json "gs://hopic-test-coverage-reports/${BRANCH_NAME}/$timestamp-${COMMIT_SHA}.json"
-    # script: |
-    #   #!/usr/bin/env bash
-    #   set -o errexit
-    #   set -o pipefail
-    #   set -o nounset
+  #       echo "Copy test coverage report from docker compose volume to Google Cloud Storage."
+  #       timestamp=$(date +%s)
+  #       gsutil cp ./coverage/coverage.json "gs://hopic-test-coverage-reports/${BRANCH_NAME}/$timestamp-${COMMIT_SHA}.json"
+    script: |
+      #!/usr/bin/env bash
+      set -o errexit
+      set -o pipefail
+      set -o nounset
       
-    #   echo "Get cloud build project configuration values"
-    #   source .env.cloud_build 
+      echo "Get cloud build project configuration values"
+      source .env.cloud_build 
 
-    #   timestamp=$(date +%s)
+      timestamp=$(date +%s)
 
-    #   echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
-    #   gsutil cp ./coverage/coverage.json "gs://hopic-test-coverage-reports/${BRANCH_NAME}/$timestamp-${COMMIT_SHA}.json"
+      echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
+      gsutil cp ./coverage/coverage.json "gs://hopic-test-coverage-reports/${BRANCH_NAME}/$timestamp-${COMMIT_SHA}.json"
 
-    # - id: "Tear down tests"
-    #   name: "gcr.io/cloud-builders/docker"
-    #   script: |
-    #     #!/usr/bin/env bash
-    #     set -o errexit
-    #     set -o pipefail
-    #     set -o nounset
-
-    #     # echo "Tear down containers and volumes"
-    #     docker compose -f docker-compose.run-tests.yaml down -v
+  - id: "Tear down tests"
+    name: "gcr.io/cloud-builders/docker"
+    script: |
+      #!/usr/bin/env bash
+      set -o errexit
+      set -o pipefail
+      set -o nounset
+      
+      docker compose -f docker-compose.run-tests.yaml down -v
 
   - id: "Build image if main"
     name: "gcr.io/cloud-builders/docker"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -31,7 +31,7 @@ steps:
       source .env.cloud_build
 
       echo "Build images for testing, run tests and create report"
-      docker compose -f docker-compose.run-tests.yaml up --exit-code-from server && chown -R $USER /cpho/web/coverage
+      docker compose -f docker-compose.run-tests.yaml up --exit-code-from server
       
       # NOTE: Tests are run within docker compose. When "--exit-code-from" is used, and the build or a command fails, this flag will cause the step to fail.  
       # Test reports are generated twice:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -60,16 +60,16 @@ steps:
     #   echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
     #   gsutil cp ./coverage/coverage.json "gs://hopic-test-coverage-reports/${BRANCH_NAME}/$timestamp-${COMMIT_SHA}.json"
 
-    - id: "Tear down tests"
-      name: "gcr.io/cloud-builders/docker"
-      script: |
-        #!/usr/bin/env bash
-        set -o errexit
-        set -o pipefail
-        set -o nounset
+    # - id: "Tear down tests"
+    #   name: "gcr.io/cloud-builders/docker"
+    #   script: |
+    #     #!/usr/bin/env bash
+    #     set -o errexit
+    #     set -o pipefail
+    #     set -o nounset
 
-        # echo "Tear down containers and volumes"
-        docker compose -f docker-compose.run-tests.yaml down -v
+    #     # echo "Tear down containers and volumes"
+    #     docker compose -f docker-compose.run-tests.yaml down -v
 
   - id: "Build image if main"
     name: "gcr.io/cloud-builders/docker"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -36,7 +36,7 @@ steps:
 
   - id: "Upload test coverage reports to Google Cloud Storage"
     name: 'gcr.io/cloud-builders/gsutil'
-    entrypoint: "bash"
+    # entrypoint: "bash"
   #   args:
   #     - "-c"
   #     - |
@@ -67,7 +67,7 @@ steps:
       set -o errexit
       set -o pipefail
       set -o nounset
-      
+
       docker compose -f docker-compose.run-tests.yaml down -v
 
   - id: "Build image if main"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -51,7 +51,7 @@ steps:
       source .env.cloud_build 
 
       echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
-      gsutil cp ./coverage/coverage.json "gs://hopic-test-coverage-reports/${BRANCH}/coverage-${COMMIT_SHA}.json"
+      gsutil cp ./coverage/coverage.json "gs://hopic-test-coverage-reports/${BRANCH_NAME}/coverage-${COMMIT_SHA}.json"
       #:$BRANCH:$COMMIT_SHA:$(date +%s)
 
     # - id: "Tear down tests"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -51,7 +51,7 @@ steps:
       source .env.cloud_build 
 
       echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
-      gsutil cp ./coverage/coverage.json gs://hopic-test-coverage-reports/${BRANCH}/coverage:${COMMIT_SHA}.json
+      gsutil cp ./coverage/coverage.json gs://hopic-test-coverage-reports/$BRANCH/coverage-${COMMIT_SHA}.json
       #:$BRANCH:$COMMIT_SHA:$(date +%s)
 
     - id: "Tear down tests"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -32,7 +32,7 @@ steps:
 
       echo "Build images for testing, run tests and create report"
       # TODO: Upload coverage report to somewhere like Google Cloud Storage, and determine how to more easily access results - currently we need to dig through the Cloud Build logs in order to view the report.  
-      docker compose -f docker-compose.run-tests.yaml build --no-cache
+      # docker compose -f docker-compose.run-tests.yaml build --no-cache
       docker compose -f docker-compose.run-tests.yaml up --exit-code-from server
       # NOTE: Tests are run within docker compose. When "--exit-code-from" is used, and the build or a command fails, this flag will cause the step to fail.
       

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -61,15 +61,15 @@ steps:
     #   gsutil cp ./coverage/coverage.json "gs://hopic-test-coverage-reports/${BRANCH_NAME}/$timestamp-${COMMIT_SHA}.json"
 
     - id: "Tear down tests"
-    name: "gcr.io/cloud-builders/docker"
-    script: |
-      #!/usr/bin/env bash
-      set -o errexit
-      set -o pipefail
-      set -o nounset
+      name: "gcr.io/cloud-builders/docker"
+      script: |
+        #!/usr/bin/env bash
+        set -o errexit
+        set -o pipefail
+        set -o nounset
 
-      # echo "Tear down containers and volumes"
-      docker compose -f docker-compose.run-tests.yaml down -v
+        # echo "Tear down containers and volumes"
+        docker compose -f docker-compose.run-tests.yaml down -v
 
   - id: "Build image if main"
     name: "gcr.io/cloud-builders/docker"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -50,9 +50,10 @@ steps:
       echo "Get cloud build project configuration values"
       source .env.cloud_build
 
-      # echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
+      echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
       # echo "deployment_test_coverage_report:$BRANCH:$COMMIT_SHA:$(date +%s)""
-      # cp test_coverage_report gs://hopic-test-coverage-reports/deployment_test_coverage_report:$BRANCH:$COMMIT_SHA:$(date +%s)
+      cp ./coverage.json gs://hopic-test-coverage-reports/deployment_test_coverage_report
+      #:$BRANCH:$COMMIT_SHA:$(date +%s)
 
   - id: "Build image if main"
     name: "gcr.io/cloud-builders/docker"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -31,6 +31,7 @@ steps:
       source .env.cloud_build
 
       echo "Build images for testing, run tests and create report"
+      echo "UID=$(id -u) GID=$(id -g)"
       UID=$(id -u) GID=$(id -g) docker compose -f docker-compose.run-tests.yaml up --exit-code-from server && chown -R $USER /cpho/web/coverage
       
       # NOTE: Tests are run within docker compose. When "--exit-code-from" is used, and the build or a command fails, this flag will cause the step to fail.  

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -37,7 +37,7 @@ steps:
       # NOTE: Tests are run within docker compose. When "--exit-code-from" is used, and the build or a command fails, this flag will cause the step to fail.
       
       echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
-      cp .coverage/coverage.json gs://hopic-test-coverage-reports/deployment_test_coverage_report
+      cp ./coverage/coverage.json gs://hopic-test-coverage-reports/deployment_test_coverage_report
       
       echo "Tear down containers and volumes"
       docker compose -f docker-compose.run-tests.yaml down -v

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -36,19 +36,29 @@ steps:
 
   - id: "Upload test coverage reports to Google Cloud Storage"
     name: 'gcr.io/cloud-builders/gsutil'
-    script: |
-      #!/usr/bin/env bash
-      set -o errexit
-      set -o pipefail
-      set -o nounset
+    entrypoint: "bash"
+    args:
+      - "-c"
+      - |
+        echo "Get cloud build project configuration values"
+        source .env.cloud_build
+
+        echo "Copy test coverage report from docker compose volume to Google Cloud Storage."
+        timestamp=$(date +%s)
+        gsutil cp ./coverage/coverage.json "gs://hopic-test-coverage-reports/${BRANCH_NAME}/$timestamp-${COMMIT_SHA}.json"
+    # script: |
+    #   #!/usr/bin/env bash
+    #   set -o errexit
+    #   set -o pipefail
+    #   set -o nounset
       
-      echo "Get cloud build project configuration values"
-      source .env.cloud_build 
+    #   echo "Get cloud build project configuration values"
+    #   source .env.cloud_build 
 
-      timestamp=$(date +%s)
+    #   timestamp=$(date +%s)
 
-      echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
-      gsutil cp ./coverage/coverage.json "gs://hopic-test-coverage-reports/${BRANCH_NAME}/$timestamp-${COMMIT_SHA}.json"
+    #   echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
+    #   gsutil cp ./coverage/coverage.json "gs://hopic-test-coverage-reports/${BRANCH_NAME}/$timestamp-${COMMIT_SHA}.json"
 
     - id: "Tear down tests"
     name: "gcr.io/cloud-builders/docker"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -50,9 +50,9 @@ steps:
       echo "Get cloud build project configuration values"
       source .env.cloud_build
 
-      echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
-      echo deployment_test_coverage_report:$BRANCH:$COMMIT_SHA:$(date +%s)
-      cp test_coverage_report gs://hopic-test-coverage-reports/deployment_test_coverage_report:$BRANCH:$COMMIT_SHA:$(date +%s)
+      # echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
+      # echo "deployment_test_coverage_report:$BRANCH:$COMMIT_SHA:$(date +%s)""
+      # cp test_coverage_report gs://hopic-test-coverage-reports/deployment_test_coverage_report:$BRANCH:$COMMIT_SHA:$(date +%s)
 
   - id: "Build image if main"
     name: "gcr.io/cloud-builders/docker"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -21,6 +21,7 @@ steps:
 
   - id: "Run tests"
     name: "gcr.io/cloud-builders/docker"
+    name: 'gcr.io/cloud-builders/gsutil'
     script: |
       #!/usr/bin/env bash
       set -o errexit
@@ -34,37 +35,26 @@ steps:
       # TODO: Upload coverage report to somewhere like Google Cloud Storage, and determine how to more easily access results - currently we need to dig through the Cloud Build logs in order to view the report.  
       # docker compose -f docker-compose.run-tests.yaml build --no-cache
       docker compose -f docker-compose.run-tests.yaml up --exit-code-from server
-      # NOTE: Tests are run within docker compose. When "--exit-code-from" is used, and the build or a command fails, this flag will cause the step to fail.
+      # NOTE: Tests are run within docker compose. When "--exit-code-from" is used, and the build or a command fails, this flag will cause the step to fail.  
       
+      # echo "Tear down containers and volumes"
+      # docker compose -f docker-compose.run-tests.yaml down -v
+
+  - id: "Upload test coverage reports to Google Cloud Storage"
+    name: 'gcr.io/cloud-builders/gsutil'
+    script: |
+      #!/usr/bin/env bash
+      set -o errexit
+      set -o pipefail
+      set -o nounset
+      
+      echo "Get cloud build project configuration values"
+      source .env.cloud_build
+
       echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
-      # cp ./coverage/coverage.json gs://hopic-test-coverage-reports/deployment_test_coverage_report
+      # echo "deployment_test_coverage_report:$BRANCH:$COMMIT_SHA:$(date +%s)""
       gsutil cp ./coverage/coverage.json gs://hopic-test-coverage-reports/coverage.json
-      
-      echo "Tear down containers and volumes"
-      docker compose -f docker-compose.run-tests.yaml down -v
-
-  # - id: "Upload test coverage reports to Google Cloud Storage"
-  #   name: 'gcr.io/cloud-builders/gsutil'
-  #   script: |
-  #     #!/usr/bin/env bash
-  #     set -o errexit
-  #     set -o pipefail
-  #     set -o nounset
-      
-  #     echo "Get cloud build project configuration values"
-  #     source .env.cloud_build
-
-  #     echo "pwd is ${PWD}"
-  #     cbfilenames=`ls ./coverage`
-  #     for eachfile in $cbfilenames
-  #     do
-  #       echo $eachfile
-  #     done
-
-  #     echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
-  #     # echo "deployment_test_coverage_report:$BRANCH:$COMMIT_SHA:$(date +%s)""
-  #     cp .coverage/coverage.json gs://hopic-test-coverage-reports/deployment_test_coverage_report
-  #     #:$BRANCH:$COMMIT_SHA:$(date +%s)
+      #:$BRANCH:$COMMIT_SHA:$(date +%s)
 
   - id: "Build image if main"
     name: "gcr.io/cloud-builders/docker"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -38,6 +38,21 @@ steps:
       echo "Tear down containers and volumes"
       docker compose -f docker-compose.run-tests.yaml down -v
 
+  - id: "Upload test coverage reports to Google Cloud Storage"
+    name: 'gcr.io/cloud-builders/gsutil'
+    script: |
+      #!/usr/bin/env bash
+      set -o errexit
+      set -o pipefail
+      set -o nounset
+      
+      echo "Get cloud build project configuration values"
+      source .env.cloud_build
+
+      echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
+      echo deployment_test_coverage_report:$BRANCH:$COMMIT_SHA:$(date +%s)
+      cp test_coverage_report gs://hopic-test-coverage-reports/deployment_test_coverage_report:$BRANCH:$COMMIT_SHA:$(date +%s)
+
   - id: "Build image if main"
     name: "gcr.io/cloud-builders/docker"
     script: |

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -31,7 +31,8 @@ steps:
       source .env.cloud_build
 
       echo "Build images for testing, run tests and create report"
-      docker compose -f docker-compose.run-tests.yaml up --exit-code-from server && chown -R $USER /cpho/web/coverage
+      UID=$(id -u) GID=$(id -g) docker compose -f docker-compose.run-tests.yaml up --exit-code-from server && chown -R $USER /cpho/web/coverage
+      
       # NOTE: Tests are run within docker compose. When "--exit-code-from" is used, and the build or a command fails, this flag will cause the step to fail.  
       # Test reports are generated twice:
         # 1 - to terminal to be printed in Cloud Build Logs

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -21,7 +21,6 @@ steps:
 
   - id: "Run tests"
     name: "gcr.io/cloud-builders/docker"
-    name: 'gcr.io/cloud-builders/gsutil'
     script: |
       #!/usr/bin/env bash
       set -o errexit

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -32,6 +32,7 @@ steps:
 
       echo "Build images for testing, run tests and create report"
       # TODO: Upload coverage report to somewhere like Google Cloud Storage, and determine how to more easily access results - currently we need to dig through the Cloud Build logs in order to view the report.  
+      docker compose -f docker-compose.run-tests.yaml build --no-cache
       docker compose -f docker-compose.run-tests.yaml up --exit-code-from server
       # NOTE: Tests are run within docker compose. When "--exit-code-from" is used, and the build or a command fails, this flag will cause the step to fail.
       

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -45,8 +45,10 @@ steps:
       echo "Get cloud build project configuration values"
       source .env.cloud_build 
 
+      timestamp=$(date +%s)
+
       echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
-      gsutil cp ./coverage/coverage.json "gs://hopic-test-coverage-reports/${BRANCH_NAME}/$(date +%s)-${COMMIT_SHA}.json"
+      gsutil cp ./coverage/coverage.json "gs://hopic-test-coverage-reports/${BRANCH_NAME}/$timestamp-${COMMIT_SHA}.json"
 
     - id: "Tear down tests"
     name: "gcr.io/cloud-builders/docker"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -37,7 +37,8 @@ steps:
       # NOTE: Tests are run within docker compose. When "--exit-code-from" is used, and the build or a command fails, this flag will cause the step to fail.
       
       echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
-      cp ./coverage/coverage.json gs://hopic-test-coverage-reports/deployment_test_coverage_report
+      # cp ./coverage/coverage.json gs://hopic-test-coverage-reports/deployment_test_coverage_report
+      cp ./coverage/coverage.json gs://hopic-test-coverage-reports/coverage.json
       
       echo "Tear down containers and volumes"
       docker compose -f docker-compose.run-tests.yaml down -v

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -50,6 +50,13 @@ steps:
       echo "Get cloud build project configuration values"
       source .env.cloud_build
 
+      echo "pwd is ${PWD}"
+      pwdfilenames=`ls .`
+      for eachfile in $pwdfilenames
+      do
+        echo $eachfile
+      done
+
       echo "Copy test coverage report from docker compose volume to Google Gloud Storage."
       # echo "deployment_test_coverage_report:$BRANCH:$COMMIT_SHA:$(date +%s)""
       cp .coverage/coverage.json gs://hopic-test-coverage-reports/deployment_test_coverage_report

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -31,21 +31,14 @@ steps:
       source .env.cloud_build
 
       echo "Build images for testing, run tests and create report"
-      docker compose -f docker-compose.run-tests.yaml up --exit-code-from server
+      docker compose -f docker-compose.run-tests.yaml up --exit-code-from server && chown -R $USER /cpho/web/coverage
       # NOTE: Tests are run within docker compose. When "--exit-code-from" is used, and the build or a command fails, this flag will cause the step to fail.  
+      # Test reports are generated twice:
+        # 1 - to terminal to be printed in Cloud Build Logs
+        # 2 - to coverage.json in mounted volume.
 
   - id: "Upload test coverage reports to Google Cloud Storage"
     name: 'gcr.io/cloud-builders/gsutil'
-    # entrypoint: "bash"
-  #   args:
-  #     - "-c"
-  #     - |
-  #       echo "Get cloud build project configuration values"
-  #       source .env.cloud_build
-
-  #       echo "Copy test coverage report from docker compose volume to Google Cloud Storage."
-  #       timestamp=$(date +%s)
-  #       gsutil cp ./coverage/coverage.json "gs://hopic-test-coverage-reports/${BRANCH_NAME}/$timestamp-${COMMIT_SHA}.json"
     script: |
       #!/usr/bin/env bash
       set -o errexit

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -51,8 +51,8 @@ steps:
       source .env.cloud_build
 
       echo "pwd is ${PWD}"
-      pwdfilenames=`ls .`
-      for eachfile in $pwdfilenames
+      cbfilenames=`ls ./coverage`
+      for eachfile in $cbfilenames
       do
         echo $eachfile
       done

--- a/deploy/gcloud_env_vars.sh
+++ b/deploy/gcloud_env_vars.sh
@@ -22,6 +22,8 @@ export GITHUB_MAIN_BRANCH_NAME=main
 # NOTE: if PROJECT_IS_USING_WHITENOISE is true then no cloud storage will be created for the project
 export PROJECT_IS_USING_WHITENOISE=true
 
+export TEST_COVERAGE_BUCKET_NAME=hopic-test-coverage-reports
+
 #########################################
 # Derived & less likely to need changes #
 #########################################

--- a/docker-compose.run-tests.yaml
+++ b/docker-compose.run-tests.yaml
@@ -18,6 +18,8 @@ services:
     image: cpho-test-image
     command: >
       sh -c "
+      mkdir -p /cpho/web/coverage &&
+      chown -R ${USER} /cpho/web/coverage && 
       coverage run -m pytest &&
       coverage report --show-missing &&
       coverage json -o /cpho/web/coverage/coverage.json --pretty-print"

--- a/docker-compose.run-tests.yaml
+++ b/docker-compose.run-tests.yaml
@@ -20,7 +20,7 @@ services:
     command: >
       sh -c "
       coverage run -m pytest &&
-      coverage report --show-missing"
+      coverage report --show-missing -o coverage.json --pretty-print"
     env_file:
       - ./server/.env.dev-public
     environment:
@@ -29,6 +29,9 @@ services:
     #       decouple.Config looks in OS env vars before .env files. 
     #       If the behaviour changes, or if this is run without using decouple, setting DB_HOST=db here will no longer work. 
       - DB_HOST=db
+    volumes: 
+    # host machine - workspace?
+      - /Users/lilakelland/Documents/code/cpho-phase2:/cpho/web
     depends_on:
       - db
 
@@ -39,8 +42,8 @@ volumes:
 networks:
   default:
     name: cloudbuild
-    external: true
-    # external: false
+    # external: true
+    external: false
 # NOTE:  An issue with error around network label being incorrect - fixed by: "docker network create --label com.docker.compose.network=cloudbuild cloudbuild"
 
 

--- a/docker-compose.run-tests.yaml
+++ b/docker-compose.run-tests.yaml
@@ -42,8 +42,8 @@ volumes:
 networks:
   default:
     name: cloudbuild
-    # external: true
-    external: false
+    external: true
+    # external: false
 # NOTE:  An issue with error around network label being incorrect - fixed by: "docker network create --label com.docker.compose.network=cloudbuild cloudbuild"
 
 

--- a/docker-compose.run-tests.yaml
+++ b/docker-compose.run-tests.yaml
@@ -20,7 +20,8 @@ services:
     command: >
       sh -c "
       coverage run -m pytest &&
-      coverage report --show-missing -o coverage.json --pretty-print"
+      coverage report --show-missing &&
+      coverage json --pretty-print"
     env_file:
       - ./server/.env.dev-public
     environment:
@@ -29,9 +30,6 @@ services:
     #       decouple.Config looks in OS env vars before .env files. 
     #       If the behaviour changes, or if this is run without using decouple, setting DB_HOST=db here will no longer work. 
       - DB_HOST=db
-    volumes: 
-    # host machine - workspace?
-      - /Users/lilakelland/Documents/code/cpho-phase2:/cpho/web
     depends_on:
       - db
 

--- a/docker-compose.run-tests.yaml
+++ b/docker-compose.run-tests.yaml
@@ -16,6 +16,7 @@ services:
   server:
     build: ./server
     image: cpho-test-image
+    user: "${USER}:${USER}" 
     command: >
       sh -c "
       mkdir -p /cpho/web/coverage &&

--- a/docker-compose.run-tests.yaml
+++ b/docker-compose.run-tests.yaml
@@ -16,7 +16,7 @@ services:
   server:
     build: ./server
     image: cpho-test-image
-    user: "${UID}:${GID}"
+    user: root
     command: >
       sh -c "
       coverage run -m pytest &&

--- a/docker-compose.run-tests.yaml
+++ b/docker-compose.run-tests.yaml
@@ -1,5 +1,4 @@
 # Docker compose file for running tests.
-# Note: If testing locally, change the network to external: false.
 
 version: '3.8'
 
@@ -21,7 +20,7 @@ services:
       sh -c "
       coverage run -m pytest &&
       coverage report --show-missing &&
-      coverage json --pretty-print"
+      coverage json -o /cpho/web/coverage/coverage.json --pretty-print"
     env_file:
       - ./server/.env.dev-public
     environment:
@@ -30,6 +29,8 @@ services:
     #       decouple.Config looks in OS env vars before .env files. 
     #       If the behaviour changes, or if this is run without using decouple, setting DB_HOST=db here will no longer work. 
       - DB_HOST=db
+    volumes:
+      - ./coverage:/cpho/web/coverage 
     depends_on:
       - db
 
@@ -41,7 +42,6 @@ networks:
   default:
     name: cloudbuild
     external: true
-    # external: false
 # NOTE:  An issue with error around network label being incorrect - fixed by: "docker network create --label com.docker.compose.network=cloudbuild cloudbuild"
 
 

--- a/docker-compose.run-tests.yaml
+++ b/docker-compose.run-tests.yaml
@@ -16,11 +16,9 @@ services:
   server:
     build: ./server
     image: cpho-test-image
-    user: "${USER}:${USER}" 
+    user: "${UID}:${GID}"
     command: >
       sh -c "
-      mkdir -p /cpho/web/coverage &&
-      chown -R ${USER} /cpho/web/coverage && 
       coverage run -m pytest &&
       coverage report --show-missing &&
       coverage json -o /cpho/web/coverage/coverage.json --pretty-print"

--- a/docker-compose.run-tests.yaml
+++ b/docker-compose.run-tests.yaml
@@ -16,7 +16,6 @@ services:
   server:
     build: ./server
     image: cpho-test-image
-    user: root
     command: >
       sh -c "
       coverage run -m pytest &&

--- a/docker-compose.run-tests.yaml
+++ b/docker-compose.run-tests.yaml
@@ -16,6 +16,7 @@ services:
   server:
     build: ./server
     image: cpho-test-image
+    user: root
     command: >
       sh -c "
       coverage run -m pytest &&

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -46,6 +46,9 @@ ENV APP_HOME=$HOME/web
 ENV VIRTUALENV=$HOME/env
 ENV WHEELDIR=$HOME/wheels
 
+# create coverage directory and set permissions during build
+RUN mkdir -p /cpho/web/coverage && chown -R $USER /cpho/web/coverage
+
 RUN \
     addgroup -S app && adduser --shell /bin/sh -u $USER -S app -G app --home $HOME && \
     mkdir -p $APP_HOME && \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -46,9 +46,6 @@ ENV APP_HOME=$HOME/web
 ENV VIRTUALENV=$HOME/env
 ENV WHEELDIR=$HOME/wheels
 
-# create coverage directory and set permissions during build
-RUN mkdir -p /cpho/web/coverage && chown -R $USER /cpho/web/coverage
-
 RUN \
     addgroup -S app && adduser --shell /bin/sh -u $USER -S app -G app --home $HOME && \
     mkdir -p $APP_HOME && \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -68,11 +68,6 @@ RUN echo -e "cd $APP_HOME\n" >> /etc/profile && \
 # copy project
 COPY --chown=$USER:app . $APP_HOME
 
-# Create a directory for the coverage report
-RUN mkdir -p /cpho/web/coverage
-# Set the directory permissions to allow writing
-RUN chown -R $USER /cpho/web/coverage
-
 # change to the app user
 USER $USER
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -68,6 +68,11 @@ RUN echo -e "cd $APP_HOME\n" >> /etc/profile && \
 # copy project
 COPY --chown=$USER:app . $APP_HOME
 
+# Create a directory for the coverage report
+RUN mkdir -p /cpho/web/coverage
+# Set the directory permissions to allow writing
+RUN chown -R $USER /cpho/web/coverage
+
 # change to the app user
 USER $USER
 


### PR DESCRIPTION
Will close #75 (Upload coverage reports & make more visible), we're adding the reports (in addition to printing them in logs) to the Google Cloud Storage [hopic-test-coverage-reports bucket](https://console.cloud.google.com/storage/browser/hopic-test-coverage-reports;tab=objects?forceOnBucketsSortingFiltering=true&project=phx-01h4rr1468rj3v5k60b1vserd3&prefix=&forceOnObjectsSortingFiltering=false).  The reports are saved under a branch-named folder, as json with filenames of \<timestamp\>-\<commit-sha\>.json.

(Note - chose json so we could easily pull out what we needed if reporting back somewhere like GitHub, but the [flag options are more limited than report](https://coverage.readthedocs.io/en/7.2.7/config.html#json) and it prints out excess lines.)

Unfortunately, as a result, cloudbuild.yaml now has additional steps as it seems you can use 'name' gcr.io/cloud-builders/gsutil, gcr.io/cloud-builders/docker or gcr.io/cloud-builders/gcloud, but not combine, so I separated the steps out (docker compose up, copy report from volume to gcs, tear down).  If this is a potential issue we could look into combining the tests/ load/ tear down into one step by also downloading the tools needed (gcloud/ gsutil) in that same step, but that seemed messier. 

The teardown step technically isn't required, but I think you mentioned on the last test PR that it's best practice.  I was thinking of potentially loading the coverage report within the docker compose, but then that would required passing credentials and loading the gsutil component, and it then wouldn’t be reusable for running tests locally.   

There was an issue with permissions to access the docker volume - tried a few iterations, but flagged it back to user:root in the docker-compose file.  I imagine this will change.  (I was trying out adding the dir in Dockerfile then giving permissions there, but I think I was doing it wrong, and not entirely sure what permissions it needs for cloudbuild. )

This also assumes that the google cloud storage API is enabled and that cloudbuild has read-write permissions. 
