### PR TITLE
Enabled container vulnerability scanning

### DIFF
--- a/deploy/gcloud_init_setup.sh
+++ b/deploy/gcloud_init_setup.sh
@@ -28,6 +28,9 @@ if [[ "${artifact_skip}" != "S" ]]; then
   
   # Authorize local docker client to push/pull images to artifact registry
   gcloud auth configure-docker "${PROJECT_REGION}-docker.pkg.dev"
+
+  # Enable Artifact Registry vulnerability scanning 
+  gcloud services enable containerscanning.googleapis.com
 fi
 
 


### PR DESCRIPTION
Will close #83 

Added line in Artifact Registry section of gcloud_init_setup.sh per https://cloud.google.com/artifact-analysis/docs/enable-container-scanning.