### PR TITLE
Cloud SQL observability configuration (DB audit logging, improved OpenTelemetry tracing)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,15 @@
       "justMyCode": true
     },
     {
+      "name": "gunicorn",
+      "type": "python",
+      "request": "launch",
+      "program": "${workspaceFolder}/venv/bin/gunicorn",
+      "cwd": "${workspaceFolder}/server",
+      "django": true,
+      "justMyCode": true
+    },
+    {
       "name": "test",
       "type": "python",
       "request": "launch",

--- a/deploy/gcloud_env_vars.sh
+++ b/deploy/gcloud_env_vars.sh
@@ -17,7 +17,7 @@ export PROJECT_REGION=northamerica-northeast1
 export BUILD_GITHUB_REPO_NAME=cpho-phase2
 export BUILD_GITHUB_REPO_OWNER=PHACDataHub
 
-export GITHUB_MAIN_BRANCH_NAME=main
+export GITHUB_MAIN_BRANCH_NAME=database-observability-configuration # main TODO revert this before merging
 
 # NOTE: if PROJECT_IS_USING_WHITENOISE is true then no cloud storage will be created for the project
 export PROJECT_IS_USING_WHITENOISE=true

--- a/deploy/gcloud_env_vars.sh
+++ b/deploy/gcloud_env_vars.sh
@@ -17,7 +17,7 @@ export PROJECT_REGION=northamerica-northeast1
 export BUILD_GITHUB_REPO_NAME=cpho-phase2
 export BUILD_GITHUB_REPO_OWNER=PHACDataHub
 
-export GITHUB_MAIN_BRANCH_NAME=database-observability-configuration # main TODO revert this before merging
+export GITHUB_MAIN_BRANCH_NAME=main
 
 # NOTE: if PROJECT_IS_USING_WHITENOISE is true then no cloud storage will be created for the project
 export PROJECT_IS_USING_WHITENOISE=true

--- a/deploy/gcloud_init_setup.sh
+++ b/deploy/gcloud_init_setup.sh
@@ -215,6 +215,7 @@ if [[ "${sql_skip}" != "S" ]]; then
     # configuration for pgaudit
     "cloudsql.enable_pgaudit=on" # remember to re-include this, or it will be referted to its default
     "pgaudit.log=all,-misc"
+    "pgaudit.log_relation=on"
 
     # keep statement logging (DDL, queries) off, already captured better by pgaudit
     "log_statement=none" 
@@ -232,9 +233,9 @@ if [[ "${sql_skip}" != "S" ]]; then
   alt_delimiter=":"
   database_flags_arg_string="^${alt_delimiter}^$(printf "%s${alt_delimiter}" "${database_flags_array[@]}" | sed 's/.$//')" 
   gcloud sql instances patch "${DB_INSTANCE_NAME}" --database-flags "${database_flags_arg_string}"
-      
+
   # TODO it's recommended to configure and enable automatic storage increase limit for Cloud SQL, especially with pgaudit on. Look in to that
-  
+
   # TODO it's recommended to enforce TLS connections in Cloud SQL. Look in to that
 
   # Enable and configure GCP Query Insights https://cloud.google.com/sql/docs/postgres/using-query-insights#enable-insights

--- a/deploy/gcloud_init_setup.sh
+++ b/deploy/gcloud_init_setup.sh
@@ -94,7 +94,10 @@ if [[ "${build_skip}" != "S" ]]; then
       echo "Bucket created."
   else
     echo "Bucket already exists."
+  fi
 fi
+
+
 
 # ----- CLOUD STORAGE (optional) -----
 if [ ! $PROJECT_IS_USING_WHITENOISE ]; then
@@ -188,7 +191,60 @@ if [[ "${sql_skip}" != "S" ]]; then
     --no-assign-ip \
     --allocated-ip-range-name "${VPC_SERVICE_CONNECTION_NAME}" \
     --enable-google-private-path
+
+  # To properly enable and configure pgaudit, we can't set all the database flags at once. Need to:
+  #   1) set the database flag `cloudsql.enable_pgaudit=on`
+  #     - pre-requisite for enabling the pgaudit extension
+  #   2) run `CREATE EXTENSION pgaudit;` on the instance
+  #     - pre-requisite for setting any other pgaudit configuration flags
+  #   3) set final flags, both pgaudit and non-pgaudit flags
+  #     - doing this last because the gcloud method for setting flags always reverts unspecified flags
+  #      to their defaults, meaning all final flags must be set in a single go
+  gcloud sql instances patch "${DB_INSTANCE_NAME}" --database-flags cloudsql.enable_pgaudit=on
+
+  # TODO run `CREATE EXTENSION pgaudit;` on the instance
+
+  # PostgreSQL database flags for logging configuration and best-practice. Written in a bash array for legibility,
+  # cast to string for use. Some of the references consulted:
+  #  - https://cloud.google.com/sql/docs/postgres/flags#list-flags-postgres
+  #  - https://www.trendmicro.com/cloudoneconformity-staging/knowledge-base/gcp/CloudSQL/
+  #    - many of the suggested settings are already the Cloud SQL default, won't duplicate those here
+  #  - https://www.enterprisedb.com/blog/how-get-best-out-postgresql-logs
+  #  - https://medium.com/google-cloud/correlate-statement-logs-in-cloudsql-for-postgres-with-connection-sessions-5bae4ade38f5
+  database_flags_array=(
+    # configuration for pgaudit
+    "cloudsql.enable_pgaudit=on" # remember to re-include this, or it will be referted to its default
+    "pgaudit.log=all,-misc"
+
+    # keep statement logging (DDL, queries) off, already captured better by pgaudit
+    "log_statement=none" 
+    # enable other misc logging
+    "log_min_messages=error"
+    "log_checkpoints=on"
+    "log_lock_waits=on"
+    "log_temp_files=0"
+    "log_connections=on"
+    "log_disconnections=on"
+    "log_hostname=on" # modifier for log_connections
+  )
+  # See `gcloud topic escaping`; an alternate delimeter, declared between two ^'s, is needed when flag values themselves might contain commas
+  # Note that using printf to joing the array to a string leaves a trailing delimiter that needs to be trimmed (using sed here)
+  alt_delimiter=":"
+  database_flags_arg_string="^${alt_delimiter}^$(printf "%s${alt_delimiter}" "${database_flags_array[@]}" | sed 's/.$//')" 
+  gcloud sql instances patch "${DB_INSTANCE_NAME}" --database-flags "${database_flags_arg_string}"
+      
+  # TODO it's recommended to configure and enable automatic storage increase limit for Cloud SQL, especially with pgaudit on. Look in to that
   
+  # TODO it's recommended to enforce TLS connections in Cloud SQL. Look in to that
+
+  # Enable and configure GCP Query Insights https://cloud.google.com/sql/docs/postgres/using-query-insights#enable-insights
+  # Query insights + tags must be enabled for Cloud SQL to automatically pull out OpenTelemetry sqlcommenter comments and
+  # add them to our traces. Note: query insights only processes a maximum of 20 queries per minute, so DB tracing will always be spotty
+  gcloud sql instances patch "${DB_INSTANCE_NAME}" \
+    --insights-config-query-insights-enabled \
+    --insights-config-record-application-tags \
+    --insights-config-query-plans-per-minute 20 
+
   # Create Database
   gcloud sql databases create "${DB_NAME}" \
     --instance "${DB_INSTANCE_NAME}"

--- a/deploy/gcloud_init_setup.sh
+++ b/deploy/gcloud_init_setup.sh
@@ -213,7 +213,7 @@ if [[ "${sql_skip}" != "S" ]]; then
   #  - https://medium.com/google-cloud/correlate-statement-logs-in-cloudsql-for-postgres-with-connection-sessions-5bae4ade38f5
   database_flags_array=(
     # configuration for pgaudit
-    "cloudsql.enable_pgaudit=on" # remember to re-include this, or it will be referted to its default
+    "cloudsql.enable_pgaudit=on"
     "pgaudit.log=all,-misc"
     "pgaudit.log_relation=on"
 

--- a/server/gunicorn.conf.py
+++ b/server/gunicorn.conf.py
@@ -1,5 +1,7 @@
 import os
 
+from server.open_telemetry_util import instrument_app_for_open_telemetry
+
 # See https://cloud.google.com/run/docs/tips/python#optimize_gunicorn
 
 # PORT env var is set by Cloud Run
@@ -15,9 +17,19 @@ threads = 8
 timeout = 0  # from the GCP docs: "timeout is set to 0 to disable the timeouts of the workers to allow Cloud Run to handle instance scaling."
 
 # Preloading is recommended by the GCP docs, with caveats; gotta be aware of what might be preloaded/resources used in the process
-# Warning: preloading loads the app before gunicorn forks. This may conflict with potential uses of gunicorn hooks like post_fork.
+# Warning: preloading loads the app before gunicorn forks, meaning it's NOT compatible with situations where some initialization must occur in a post_fork hook
 # E.g. if we use OpenTelemetry's background process based BatchSpanProcessor, then we need to insturment the app from the post_fork hook,
 # to get different background processses per processor. Instrumentation needs to happen before the app launches, so in this case preload_app can't be used
-preload_app = True
+# preload_app = True
+
+
+def post_fork(server, worker):
+    # When using OpenTelemetry's background process based BatchSpanProcessor, insturmentation must occur post process fork. Pre-fork instrumentation
+    # would result in each app process trying to share the same BatchSpanProcessor background process, which would not be reliable.
+    # If NOT using BatchSpanProcessor (likely a bad idea, it's much more performant at run time) you can move these lines to wsgi.py and enable preload_app
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.settings")
+
+    instrument_app_for_open_telemetry()
+
 
 wsgi_app = "server.wsgi:application"

--- a/server/gunicorn.conf.py
+++ b/server/gunicorn.conf.py
@@ -30,7 +30,9 @@ def post_fork(server, worker):
 
 
 def worker_exit(server, worker):
-    worker.log.info("Flushing telemetry for exiting gunicorn worker...")
+    worker.log.info(
+        f"Flushing telemetry for exiting worker (pid: {worker.pid})"
+    )
     worker.flush_telemetry_callback()
 
 

--- a/server/gunicorn.conf.py
+++ b/server/gunicorn.conf.py
@@ -8,28 +8,34 @@ from server.open_telemetry_util import instrument_app_for_open_telemetry
 PORT = os.getenv("PORT", "8080")
 bind = [f"0.0.0.0:{PORT}"]
 
-# Note: the generally recommended formula is `workers + threads = multiprocessing.cpu_count() * 2 + 1`,
-# not totally clear why these google doc tips use 8 threads. Haven't confirmed that `multiprocessing.cpu_count()`
-# is accurate in Cloud Run serverless environment anyway (I know JS libraries used to incorrectly detect vCPUs all the time)
-workers = 1  # increase this, and possibly decrease threads, if we ever configure a higher CPU count for Cloud Run
-threads = 8
+# Note: the generally recommended formula is `workers + threads = cpu_count * 2 + 1`, although gunicorn  describes this as "not overly scientific".
+# Cloud Run only has one vCPU by default, but Google doc Cloud Run gunicorn examples configure one worker and 8 threads consistently
+workers = 1  # increase this, and potentially adjust threads, if we ever configure a higher CPU count for Cloud Run
+threads = 4  # half of what GCP examples use, as each of our app process will use at least two threads (app thread + BatchSpanProcessor worker thread)
 
 timeout = 0  # from the GCP docs: "timeout is set to 0 to disable the timeouts of the workers to allow Cloud Run to handle instance scaling."
 
-# Preloading is recommended by the GCP docs, with caveats; gotta be aware of what might be preloaded/resources used in the process
+# Preloading is recommended by the GCP docs, with caveats; gotta be aware of what might be preloaded/resources used in the process/any gunicorn hooks used
 # Warning: preloading loads the app before gunicorn forks, meaning it's NOT compatible with situations where some initialization must occur in a post_fork hook
-# E.g. if we use OpenTelemetry's background process based BatchSpanProcessor, then we need to insturment the app from the post_fork hook,
-# to get different background processses per processor. Instrumentation needs to happen before the app launches, so in this case preload_app can't be used
 # preload_app = True
 
 
 def post_fork(server, worker):
-    # When using OpenTelemetry's background process based BatchSpanProcessor, insturmentation must occur post process fork. Pre-fork instrumentation
-    # would result in each app process trying to share the same BatchSpanProcessor background process, which would not be reliable.
-    # If NOT using BatchSpanProcessor (likely a bad idea, it's much more performant at run time) you can move these lines to wsgi.py and enable preload_app
+    # When using OpenTelemetry's background process based BatchSpanProcessor, insturmentation must occur post worker forking. Pre-fork instrumentation
+    # would result in each app process trying to share the same BatchSpanProcessor worker thread, which would not be reliable.
+    # If NOT using BatchSpanProcessor (likely a bad idea, it's much more performant at run time) you can move instrumentation to wsgi.py and enable preload_app
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.settings")
 
-    instrument_app_for_open_telemetry()
+    worker.flush_telemetry_callback = instrument_app_for_open_telemetry()
+
+
+def worker_exit(server, worker):
+    try:
+        worker.flush_telemetry_callback()
+    except AttributeError:
+        worker.log.error(
+            "Worker does not have expected flush_telemetry_callback function"
+        )
 
 
 wsgi_app = "server.wsgi:application"

--- a/server/gunicorn.conf.py
+++ b/server/gunicorn.conf.py
@@ -30,12 +30,8 @@ def post_fork(server, worker):
 
 
 def worker_exit(server, worker):
-    try:
-        worker.flush_telemetry_callback()
-    except AttributeError:
-        worker.log.error(
-            "Worker does not have expected flush_telemetry_callback function"
-        )
+    worker.log.info("Flushing telemetry for exiting gunicorn worker...")
+    worker.flush_telemetry_callback()
 
 
 wsgi_app = "server.wsgi:application"

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -22,6 +22,7 @@ rules==3.3
 # opentelemetry
 opentelemetry-sdk==1.19.0
 opentelemetry-instrumentation-django==0.40b0
+opentelemetry-instrumentation-psycopg2==0.40b0
 opentelemetry-resourcedetector-gcp==1.5.0a0
 opentelemetry-propagator-gcp==1.5.0
 opentelemetry-exporter-gcp-trace==1.5.0

--- a/server/server/open_telemetry_util.py
+++ b/server/server/open_telemetry_util.py
@@ -2,7 +2,6 @@ import os
 import sys
 
 import requests
-import structlog
 from opentelemetry import trace
 from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
 from opentelemetry.instrumentation.django import DjangoInstrumentor
@@ -122,3 +121,8 @@ def instrument_app_for_open_telemetry():
         # redundant to the preferable Psycopg2Instrumentor commenter
         is_sql_commentor_enabled=False,
     )
+
+    def flush_telemetry_callback():
+        tracer_provider.shutdown()
+
+    return flush_telemetry_callback

--- a/server/server/open_telemetry_util.py
+++ b/server/server/open_telemetry_util.py
@@ -68,7 +68,7 @@ def instrument_app_for_open_telemetry():
     # Propagate the X-Cloud-Trace-Context header if present. Add it otherwise
     set_global_textmap(CloudTraceFormatPropagator())
 
-    # A BatchSpanProcessor is signiicantly better for performance, but has some caveats:
+    # A BatchSpanProcessor is significantly better for performance, but has some caveats:
     #   1) gunicorn caveat: it uses a worker thread, which means instrumentation calls must happen post-gunicorn
     #   worker fork, or else multiple gunicron app worker threads will attempt to share one BatchSpanProcessor
     #   worker (and trip over eachother's process locks)

--- a/server/server/open_telemetry_util.py
+++ b/server/server/open_telemetry_util.py
@@ -6,6 +6,7 @@ import structlog
 from opentelemetry import trace
 from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
 from opentelemetry.instrumentation.django import DjangoInstrumentor
+from opentelemetry.instrumentation.psycopg2 import Psycopg2Instrumentor
 from opentelemetry.propagate import set_global_textmap
 from opentelemetry.propagators.cloud_trace_propagator import (
     CloudTraceFormatPropagator,
@@ -104,9 +105,18 @@ def instrument_app_for_open_telemetry():
             }
         )
 
+    Psycopg2Instrumentor().instrument(
+        tracer_provider=tracer_provider,
+        enable_commenter=True,
+        commenter_options={},
+        skip_dep_check=True,
+    )
+
     DjangoInstrumentor().instrument(
         tracer_provider=tracer_provider,
         meter_provider=None,  # TODO
         request_hook=associate_request_logs_to_telemetry,
-        is_sql_commentor_enabled=True,
+        # confusingly named (typo included), this actually adds a sqlcommenter middleware, and is
+        # redundant to the preferable Psycopg2Instrumentor commenter
+        is_sql_commentor_enabled=False,
     )

--- a/server/server/open_telemetry_util.py
+++ b/server/server/open_telemetry_util.py
@@ -109,6 +109,8 @@ def instrument_app_for_open_telemetry():
         tracer_provider=tracer_provider,
         enable_commenter=True,
         commenter_options={},
+        # This instrumentor expects the `psycopg2` package. This repo uses the `psycopg2-binary` package.
+        # Compatible with both, but need to disable the instrumentor's dependency checking
         skip_dep_check=True,
     )
 

--- a/server/server/open_telemetry_util.py
+++ b/server/server/open_telemetry_util.py
@@ -17,8 +17,8 @@ from opentelemetry.resourcedetector.gcp_resource_detector import (
 from opentelemetry.sdk.resources import ProcessResourceDetector
 from opentelemetry.sdk.trace import TracerProvider, sampling
 from opentelemetry.sdk.trace.export import (
+    BatchSpanProcessor,
     ConsoleSpanExporter,
-    SimpleSpanProcessor,
 )
 
 from server.config_util import get_project_config, is_running_tests
@@ -73,7 +73,7 @@ def instrument_app_for_open_telemetry():
     # which would require tricky and careful management in Cloud Run. Even in the best case,
     # I expect the necessary tricks would still result in the occasional dropped trace.
     # BatchSpanProcessor also requires extra configuration when combined with gunicorn's process forking
-    span_processor = SimpleSpanProcessor(span_exporter)
+    span_processor = BatchSpanProcessor(span_exporter)
 
     tracer_provider = TracerProvider(
         active_span_processor=span_processor,

--- a/server/server/open_telemetry_util.py
+++ b/server/server/open_telemetry_util.py
@@ -123,6 +123,7 @@ def instrument_app_for_open_telemetry():
     )
 
     def flush_telemetry_callback():
+        tracer_provider.force_flush()
         tracer_provider.shutdown()
 
     return flush_telemetry_callback

--- a/server/server/wsgi.py
+++ b/server/server/wsgi.py
@@ -11,10 +11,4 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-from server.open_telemetry_util import instrument_app_for_open_telemetry
-
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.settings")
-
-instrument_app_for_open_telemetry()
-
 application = get_wsgi_application()


### PR DESCRIPTION
Related to #84

TODO:
  - [x] configure Cloud SQL postgres database flags for better logging
    - related steps added to `gcloud_init_setup.sh`
    - one step remains a TODO, running `CREATE EXTENSION pgaudit;` inside the DB instance. See #84 
  - [x] add `Psycopg2Instrumentor` to the application for better DB tracing
  - [x] to deal with the growing performance impact of all this extra telemetry, switched from `SimpleSpanProcessor` to `BatchSpanProcessor`. `BatchSpanProcessor` uses a worker thread; using it safely with requires special consideration for both gunicorn and the Cloud Run environment
    - [x] for gunicorn, needed to move instrumentation in to a gunicorn `post_fork` hook, so that  `BatchSpanProcessor` and application instance worker threads would be 1-to-1. This prevents us from using `preload_app = True`, but it's a net performance win even without gunicorn preloads
    - [x] for Cloud Run, there are two big things to account for when running anything in a background process or worker thread:
      - [x] Cloud Run containers only get CPU time while handling a request. We specifically don't want to hold up responses to wait on telemetry processing, so we can't guarantee that the `BatchSpanProcessor` won't still have un-flushed traces on its worker thread when it's throttled off the CPU. The processes will continue work the next time a request comes in/CPU is allocated, so this may makes our traces eventual rather than instant. This isn't something we have to remediate ourselves, just something to be aware of
      - [x] what about `BatchSpanProcessor` that hasn't yet resolved when a container is fully killed, rather than just temporarily throttled?  GCP promises 10 seconds of grace-period CPU time for processes to respond to the `SIGTERM` signal and exit. To make use of this, I attach a `flush_telemetry_callback` to each spawned worker in our gunicorn `post_fork` hook, and call that function from our `worker_exit` hook. Gunicorn will receive and handle the `SIGTERM` and, unless our containers are massively slow/clogged up with exit tasks, there should be plenty of time during those 10 seconds to flush the `BatchSpanProcessor`(s) 
    - I figure eventual traces are better than dropped traces, and both are better than significantly slowing down request handling
    
For reference, here's an example of the benefits from the Trace Explorer perspective. 
![image](https://github.com/PHACDataHub/cpho-phase2/assets/11301919/83be9fa2-0fb0-4d85-bc2a-e83600953b8b)
The selected span in the trace below is from `Psycopg2Instrumentor`; we always get there for every DB query. The sub-spans of that (Cloud SQL Query, Aggregate, Index Scan) are generated from the DB's logs; this is enabled by the metadata included in each query statement by `sqlcommenter`, which Cloud SQL Query Insights will see in statement logs and use to construct after the fact trace information. Note that there's a limit there, Query Insights will only do this for up to the first 20 queries logged in a minute, and seems to often choose to sample from less.  

That's annoying, but it's not a big deal. You can grab the parent span ID from a `Psycopg2Instrumentor` span, or the overall trace ID for the request, and search for it in the log explorer to pull up all the fine details :+1:.

