### PR TITLE
Add script to support the use of cloud-sql-proxy in dev

### DIFF
--- a/deploy/connect_cloud_sql_proxy.sh
+++ b/deploy/connect_cloud_sql_proxy.sh
@@ -13,6 +13,8 @@ if ! which cloud-sql-proxy; then
   exit 1
 fi
 
+local_access_env_path=$(dirname "${BASH_SOURCE[0]}")/../server/.env.prod
+
 function cleanup {
   echo ""
   echo "Deleting temporary app env file"
@@ -30,7 +32,7 @@ trap cleanup EXIT
 
 echo ""
 echo "Enabling public IP for database instance, initially configured to refuse all public IP connections"
-gcloud sql instances patch "${DB_INSTANCE_NAME}" --clear-authorized-networks --assign-ip
+gcloud sql instances patch "${DB_INSTANCE_NAME}" --clear-authorized-networks --assign-ip --quiet
 
 echo ""
 echo "Adding current machine's external IP address to the DB's allow list"
@@ -38,9 +40,8 @@ echo "Adding current machine's external IP address to the DB's allow list"
 # ask whoever received it what they see it as (on the far side of your router, ISP, any other intermediate networks, etc)
 # ... so we're trusting that ipinfo.io doesn't lie to us. If we keep this approach long term, maybe we host our own IP reflector? 
 external_ip=$(curl https://ipinfo.io/ip)
-gcloud sql instances patch "${DB_INSTANCE_NAME}" --authorized-networks "${external_ip}"
+gcloud sql instances patch "${DB_INSTANCE_NAME}" --authorized-networks "${external_ip}" --quiet
 
-local_access_env_path=$(dirname "${BASH_SOURCE[0]}")/../server/.env.prod
 echo ""
 echo "Getting a temporary env file that configures the local dev app for prod DB access, written to ${local_access_env_path}"
 gcloud secrets versions access latest --secret "${SKEY_LOCAL_ACCESS_PROD_ENV_FILE}" --out-file "${local_access_env_path}"

--- a/deploy/connect_cloud_sql_proxy.sh
+++ b/deploy/connect_cloud_sql_proxy.sh
@@ -6,8 +6,6 @@ set -o nounset
 # ----- Get configuration variables + secrets helpers -----
 source $(dirname "${BASH_SOURCE[0]}")/gcloud_env_vars.sh
 
-local_port=6543
-
 echo ""
 echo "Checking path for cloud-sql-proxy dependency"
 if ! which cloud-sql-proxy; then
@@ -43,6 +41,6 @@ external_ip=$(curl https://ipinfo.io/ip)
 gcloud sql instances patch "${DB_INSTANCE_NAME}" --authorized-networks "${external_ip}"
 
 echo ""
-echo "Connecting via cloud-sql-proxy. The database will be available via localhost at port ${local_port}"
+echo "Connecting via cloud-sql-proxy. The database will be available via localhost at port ${LOCAL_ACCESS_DB_PORT}"
 cloud_sql_connection_name=$(gcloud sql instances describe "${DB_INSTANCE_NAME}" --format 'value(connectionName)')
-cloud-sql-proxy "${cloud_sql_connection_name}" --address 127.0.0.1 --port "${local_port}"
+cloud-sql-proxy "${cloud_sql_connection_name}" --address 127.0.0.1 --port "${LOCAL_ACCESS_DB_PORT}"

--- a/deploy/connect_cloud_sql_proxy.sh
+++ b/deploy/connect_cloud_sql_proxy.sh
@@ -15,16 +15,16 @@ fi
 
 function cleanup {
   echo ""
-  echo "Deleting temorary app env file"
+  echo "Deleting temporary app env file"
   rm -f "${local_access_env_path}"
 
   echo ""
   echo "Revoking temporary credentials used for cloud-sql-proxy"
-  gcloud auth application-default revoke
+  gcloud auth application-default revoke --quiet
   
   echo ""
   echo "Clearing authorized public IPs and disabling the DB's public IP"
-  gcloud sql instances patch "${DB_INSTANCE_NAME}" --clear-authorized-networks --no-assign-ip
+  gcloud sql instances patch "${DB_INSTANCE_NAME}" --clear-authorized-networks --no-assign-ip --quiet
 }
 trap cleanup EXIT
 
@@ -43,7 +43,7 @@ gcloud sql instances patch "${DB_INSTANCE_NAME}" --authorized-networks "${extern
 local_access_env_path=$(dirname "${BASH_SOURCE[0]}")/../server/.env.prod
 echo ""
 echo "Getting a temporary env file that configures the local dev app for prod DB access, written to ${local_access_env_path}"
-get_secret "${SKEY_LOCAL_ACCESS_PROD_ENV_FILE}" > "${local_access_env_path}"
+gcloud secrets versions access latest --secret "${SKEY_LOCAL_ACCESS_PROD_ENV_FILE}" --out-file "${local_access_env_path}"
 
 echo ""
 echo "Getting temporary credentials for cloud-sql-proxy (oauth step)"

--- a/deploy/connect_cloud_sql_proxy.sh
+++ b/deploy/connect_cloud_sql_proxy.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# ----- Get configuration variables + secrets helpers -----
+source $(dirname "${BASH_SOURCE[0]}")/gcloud_env_vars.sh
+
+local_port=6543
+
+echo ""
+echo "Checking path for cloud-sql-proxy dependency"
+if ! which cloud-sql-proxy; then
+  echo "Path does not contain cloud-sql-proxy! Follow these docs to install it: https://cloud.google.com/sql/docs/mysql/sql-proxy#linux-64-bit"
+  exit 1
+fi
+
+echo ""
+echo "Enabling public IP for database instance, initially configured to refuse all public IP connections"
+gcloud sql instances patch "${DB_INSTANCE_NAME}" --clear-authorized-networks --assign-ip
+
+echo ""
+echo "Getting temporary credentials for cloud-sql-proxy (oauth step)"
+gcloud auth application-default login
+
+function cleanup {
+  echo ""
+  echo "Revoking temporary credentials used for cloud-sql-proxy"
+  gcloud auth application-default revoke
+  
+  echo ""
+  echo "Clearing authorized public IPs and disabling the DB's public IP"
+  gcloud sql instances patch "${DB_INSTANCE_NAME}" --clear-authorized-networks --no-assign-ip
+}
+trap cleanup EXIT
+
+echo ""
+echo "Adding current machine's external IP address to the DB's allow list"
+# Your system doesn't usually know it's own external ip, need to send a packet out of your network, and then
+# ask whoever received it what they see it as (on the far side of your router, ISP, any other intermediate networks, etc)
+# ... so we're trusting that ipinfo.io doesn't lie to us. If we keep this approach long term, maybe we host our own IP reflector? 
+external_ip=$(curl https://ipinfo.io/ip)
+gcloud sql instances patch "${DB_INSTANCE_NAME}" --authorized-networks "${external_ip}"
+
+echo ""
+echo "Connecting via cloud-sql-proxy. The database will be available via localhost at port ${local_port}"
+cloud_sql_connection_name=$(gcloud sql instances describe "${DB_INSTANCE_NAME}" --format 'value(connectionName)')
+cloud-sql-proxy "${cloud_sql_connection_name}" --address 127.0.0.1 --port "${local_port}"

--- a/deploy/gcloud_cleanup.sh
+++ b/deploy/gcloud_cleanup.sh
@@ -39,6 +39,10 @@ if "${allow_cleanup}"; then
 
   # ----- ARTIFACT REGISTRY -----
   gcloud artifacts repositories delete "${ARTIFACT_REGISTRY_REPO}" --location "${PROJECT_REGION}" || :
+
+  # ----- CLOUD STORAGE -----
+  gcloud storage buckets delete "gs://${MEDIA_BUCKET_NAME}" --location "${PROJECT_REGION}" || :
+  gcloud storage buckets delete "gs://${TEST_COVERAGE_BUCKET_NAME}" --location "${PROJECT_REGION}" || :
   
   # ----- CLOUD BUILD ----
   gcloud builds triggers delete github "${BUILD_CLOUD_BUILD_TRIGGER_NAME}" --region "${PROJECT_REGION}" || :

--- a/deploy/gcloud_env_vars.sh
+++ b/deploy/gcloud_env_vars.sh
@@ -80,7 +80,11 @@ export DB_VERSION=POSTGRES_14
 export DB_TIER=db-g1-small
 export DB_INSTANCE_NAME="${PROJECT_SERVICE_NAME}-db-instance"
 export DB_NAME="${PROJECT_SERVICE_NAME}_db"
-export DB_USER="${PROJECT_SERVICE_NAME}_db_user"
+export DB_APP_USER="${PROJECT_SERVICE_NAME}_db_user"
+export DB_LOCAL_ACCESS_USER="${PROJECT_SERVICE_NAME}_db_local_access_user"
+
+# ----- LOCAL ACCESS TO PROD DB -----
+export LOCAL_ACCESS_DB_PORT=6543
 
 # ----- VPC NETWORK -----
 export VPC_NAME=default
@@ -90,8 +94,10 @@ export VPC_CONNECTOR_RANGE="10.8.0.0/28" # must be /28 and unused. 10.8.0.0 shou
 
 # ----- SECRET MANAGER (keys only) -----
 export SKEY_DB_ROOT_PASSWORD=db_root_password
-export SKEY_DB_USER_PASSWORD=db_user_password
+export SKEY_DB_APP_USER_PASSWORD_TEMP=db_app_user_password_temp
+export SKEY_DB_LOCAL_ACCESS_USER_PASSWORD_TEMP=db_local_access_user_password_temp
 export SKEY_PROD_ENV_FILE=django_production_env
+export SKEY_LOCAL_ACCESS_PROD_ENV_FILE=django_local_prod_db_access_env
 export SKEY_PROD_SLACK_ALERTING_APP_TOKEN=slack_alerting_app_token
 
 

--- a/deploy/gcloud_init_setup.sh
+++ b/deploy/gcloud_init_setup.sh
@@ -189,6 +189,32 @@ fi
 
 
 
+# ----- CLOUD STORAGE -----
+if [ ! $PROJECT_IS_USING_WHITENOISE ]; then
+  echo ""
+  echo "Create a media bucket"
+  read -n 1 -p "Type S to skip this step, anything else to continue: " media_bucket_skip
+  echo ""
+  if [[ "${media_bucket_skip}" != "S" ]]; then
+  echo ""
+    gcloud services enable storage.googleapis.com
+
+    gcloud storage buckets create "gs://${MEDIA_BUCKET_NAME}" --location "${PROJECT_REGION}"
+  fi
+fi
+
+echo ""
+echo "Create a Google Cloud Storage bucket for test coverage reports"
+read -n 1 -p "Type S to skip this step, anything else to continue: " coverage_bucket_skip
+echo ""
+if [[ "${coverage_bucket_skip}" != "S" ]]; then
+  gcloud services enable storage.googleapis.com
+
+  gcloud storage buckets create "gs://${TEST_COVERAGE_BUCKET_NAME}" --location "${PROJECT_REGION}"
+fi
+
+
+
 # ----- CLOUD BUILD ----
 echo ""
 echo "Enable Cloud Build, triggered by GitHub pushes"
@@ -209,14 +235,21 @@ if [[ "${build_skip}" != "S" ]]; then
    
    # Set necessary roles for Cloud Build service account, including custom 
    #TODO - modify permissions & roles (i.e roles/run) to be "least-privileged"
-  cloud_build_roles=("roles/cloudbuild.serviceAgent" "roles/artifactregistry.writer" "roles/run.admin")
-
-  for role in "${cloud_build_roles[@]}"; do
-     gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
-       --member "serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com" \
-       --role "${role}"
+  cloud_build_project_roles=("roles/cloudbuild.serviceAgent" "roles/artifactregistry.writer" "roles/run.admin")
+  for role in "${cloud_build_project_roles[@]}"; do
+     cloud projects add-iam-policy-binding "${PROJECT_ID}" \
+      --member "serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com" \
+      --role "${role}"
   done
 
+  # Give Cloud Build read-write to the test coverage bucket
+  cloud_build_coverage_bucket_roles=("roles/storage.objectCreator" "roles/storage.legacyBucketReader")
+  for role in "${cloud_build_coverage_bucket_roles[@]}"; do
+    gcloud storage buckets add-iam-policy-binding "gs://${TEST_COVERAGE_BUCKET_NAME}" \
+     --member "serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com" \
+     --role "${role}"
+  done
+  
   # Give Cloud Build access to the Cloud Run service account
   gcloud iam service-accounts add-iam-policy-binding "${PROJECT_NUMBER}"-compute@developer.gserviceaccount.com \
     --member "serviceAccount:"${PROJECT_NUMBER}"@cloudbuild.gserviceaccount.com" \
@@ -243,43 +276,7 @@ if [[ "${build_skip}" != "S" ]]; then
       --include-logs-with-status \
       --no-require-approval
   fi
-
-  echo "Create a Google Cloud Storage bucket for test coverage reports"
-  if ! gsutil ls "gs://${TEST_COVERAGE_BUCKET_NAME}" &> /dev/null; then
-      gsutil mb -l "${PROJECT_REGION}" "gs://${TEST_COVERAGE_BUCKET_NAME}"
-      echo "Bucket created."
-  else
-    echo "Bucket already exists."
-  fi
 fi
-
-
-# ----- CLOUD STORAGE -----
-echo ""
-echo "Enable Cloud Storage API"
-echo ""
-gcloud services enable \
-    storage.googleapis.com
-    
-if [ ! $PROJECT_IS_USING_WHITENOISE ]; then
-  echo ""
-  echo "Create a media bucket"
-  read -n 1 -p "Type S to skip this step, anything else to continue: " bucket_skip
-  echo ""
-  if [[ "${bucket_skip}" != "S" ]]; then
-    gsutil mb -l "${PROJECT_REGION}" "gs://${MEDIA_BUCKET_NAME}"
-  fi
-fi
-
-echo "Create a Google Cloud Storage bucket for test coverage reports"
-if ! gsutil ls "gs://${TEST_COVERAGE_BUCKET_NAME}" &> /dev/null; then
-    gsutil mb -l "${PROJECT_REGION}" "gs://${TEST_COVERAGE_BUCKET_NAME}"
-    echo "Bucket created."
-else
-  echo "Bucket already exists."
-
-echo "Allow cloud build read & write permissons for ${TEST_COVERAGE_BUCKET_NAME} bucket."
-gsutil iam ch "serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com:objectCreator,legacyBucketReader" "gs://${TEST_COVERAGE_BUCKET_NAME}"
 
 
 
@@ -423,19 +420,24 @@ if [[ "${sql_skip}" != "S" ]]; then
   
   # This secret is short lived, to be deleted once the value has been saved in the .env.prod secret
   # Storing it as a secret here is just in case this script exits before the whole .env.prod is written
-  set_secret "${SKEY_DB_USER_PASSWORD}" $(openssl rand -base64 80)
-
-  # Create User
-  gcloud sql users create "${DB_USER}" \
+  set_secret "${SKEY_DB_APP_USER_PASSWORD_TEMP}" $(openssl rand -base64 80)
+  gcloud sql users create "${DB_APP_USER}" \
     --instance "${DB_INSTANCE_NAME}" \
-    --password $(get_secret "${SKEY_DB_USER_PASSWORD}")
+    --password $(get_secret "${SKEY_DB_APP_USER_PASSWORD_TEMP}")
+
+  # This secret is short lived, to be deleted once the value has been saved in the local-use .env.prod secret
+  # Storing it as a secret here is just in case this script exits before the whole local-use .env.prod is written
+  set_secret "${SKEY_DB_LOCAL_ACCESS_USER_PASSWORD_TEMP}" $(openssl rand -base64 80)
+  gcloud sql users create "${DB_LOCAL_ACCESS_USER}" \
+    --instance "${DB_INSTANCE_NAME}" \
+    --password $(get_secret "${SKEY_DB_LOCAL_ACCESS_USER_PASSWORD_TEMP}")
 fi
 
 
 
 # ----- SECRET MANAGER -----
 echo ""
-echo "Create and save .env.prod in Secret Manager"
+echo "Create and save the production app .env.prod in Secret Manager"
 read -n 1 -p "Type S to skip this step, anything else to continue: " secrets_skip
 echo ""
 if [[ "${secrets_skip}" != "S" ]]; then
@@ -449,8 +451,8 @@ if [[ "${secrets_skip}" != "S" ]]; then
   trap cleanup EXIT
 
   bash_escape "DB_NAME=${DB_NAME}" >> "${tmp_prod_env}"
-  bash_escape "DB_USER=${DB_USER}" >> "${tmp_prod_env}"
-  bash_escape "DB_PASSWORD=$(get_secret "${SKEY_DB_USER_PASSWORD}")" >> "${tmp_prod_env}"
+  bash_escape "DB_APP_USER=${DB_APP_USER}" >> "${tmp_prod_env}"
+  bash_escape "DB_PASSWORD=$(get_secret "${SKEY_DB_APP_USER_PASSWORD_TEMP}")" >> "${tmp_prod_env}"
   bash_escape "DB_HOST=$(gcloud sql instances list --filter name:"${DB_INSTANCE_NAME}" --format "value(PRIVATE_ADDRESS)")" >> "${tmp_prod_env}"
   bash_escape "DB_PORT=5432" >> "${tmp_prod_env}"
   
@@ -472,9 +474,54 @@ if [[ "${secrets_skip}" != "S" ]]; then
   rm -rf "${tmp_prod_env}"
 
   # Only want one source of truth for this, can be deleted now that it is also in the .env.prod secret
-  delete_secret "${SKEY_DB_USER_PASSWORD}"
+  delete_secret "${SKEY_DB_APP_USER_PASSWORD_TEMP}"
 fi
 
+echo ""
+echo "Create and save the local-access .env.prod, used for connecting local dev environments to the prod DB, in Secret Manager"
+read -n 1 -p "Type S to skip this step, anything else to continue: " secrets_skip
+echo ""
+if [[ "${secrets_skip}" != "S" ]]; then
+  gcloud services enable secretmanager.googleapis.com
+
+  tmp_local_access_prod_env=$(mktemp -t .env.prod-local.XXXX)
+  function cleanup {
+    rm -rf "${tmp_local_access_prod_env}"
+  }
+  trap cleanup EXIT
+
+  bash_escape "IS_LOCAL_TO_PROD_DB_ACCESS_MODE=True" >> "${tmp_local_access_prod_env}"
+
+  bash_escape "DB_NAME=${DB_NAME}" >> "${tmp_local_access_prod_env}"
+  echo "# this is NOT the same DB user/password as the live app" >> "${tmp_local_access_prod_env}"
+  bash_escape "DB_APP_USER=${DB_LOCAL_ACCESS_USER}" >> "${tmp_local_access_prod_env}"
+  bash_escape "DB_PASSWORD=$(get_secret "${SKEY_DB_LOCAL_ACCESS_USER_PASSWORD_TEMP}")" >> "${tmp_local_access_prod_env}"
+  echo "# assumes cloud-sql-proxy is proxying the prod DB locally over the configured port" >> "${tmp_local_access_prod_env}"
+  bash_escape "DB_HOST=localhost" >> "${tmp_local_access_prod_env}"
+  bash_escape "DB_PORT=${LOCAL_ACCESS_DB_PORT}" >> "${tmp_local_access_prod_env}"
+  
+  echo "# this is NOT the same Django secret key as used by the live app, but it should still be treated as secret" >> "${tmp_local_access_prod_env}"
+  echo "# as it is used to sign any sessions you create via your local app against the prod DB instance" >> "${tmp_local_access_prod_env}"
+  bash_escape "SECRET_KEY=$(python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())')" >> "${tmp_local_access_prod_env}"
+  
+  bash_escape "ALLOWED_HOSTS=localhost" >> "${tmp_local_access_prod_env}"
+  
+  if [[ ! $PROJECT_IS_USING_WHITENOISE ]]; then
+    bash_escape "MEDIA_BUCKET_NAME=${MEDIA_BUCKET_NAME}" >> "${tmp_local_access_prod_env}"
+  fi
+
+  if [[ -n $(gcloud secrets describe --verbosity none "${SKEY_LOCAL_ACCESS_PROD_ENV_FILE}")  ]]; then
+    gcloud secrets versions add "${SKEY_LOCAL_ACCESS_PROD_ENV_FILE}" --data-file "${tmp_local_access_prod_env}"
+  else
+    gcloud secrets create --locations "${PROJECT_REGION}" --replication-policy user-managed "${SKEY_LOCAL_ACCESS_PROD_ENV_FILE}" --data-file "${tmp_local_access_prod_env}"
+  fi
+
+  # Not strictly necessary with the exit trap, but may as well delete this quickly once it's served it's purpose
+  rm -rf "${tmp_local_access_prod_env}"
+
+  # Only want one source of truth for this, can be deleted now that it is also in the .env.prod secret
+  delete_secret "${SKEY_DB_LOCAL_ACCESS_USER_PASSWORD_TEMP}"
+fi
 
 
 # ----- CLOUD RUN -----

--- a/deploy/gcloud_init_setup.sh
+++ b/deploy/gcloud_init_setup.sh
@@ -451,7 +451,7 @@ if [[ "${secrets_skip}" != "S" ]]; then
   trap cleanup EXIT
 
   bash_escape "DB_NAME=${DB_NAME}" >> "${tmp_prod_env}"
-  bash_escape "DB_APP_USER=${DB_APP_USER}" >> "${tmp_prod_env}"
+  bash_escape "DB_USER=${DB_APP_USER}" >> "${tmp_prod_env}"
   bash_escape "DB_PASSWORD=$(get_secret "${SKEY_DB_APP_USER_PASSWORD_TEMP}")" >> "${tmp_prod_env}"
   bash_escape "DB_HOST=$(gcloud sql instances list --filter name:"${DB_INSTANCE_NAME}" --format "value(PRIVATE_ADDRESS)")" >> "${tmp_prod_env}"
   bash_escape "DB_PORT=5432" >> "${tmp_prod_env}"
@@ -492,10 +492,10 @@ if [[ "${secrets_skip}" != "S" ]]; then
 
   echo "# this is NOT the production application env file BUT it does contain credentials for the production database. Handle appropriately"
   bash_escape "IS_LOCAL=True" >> "${tmp_local_access_prod_env}"
-  
+
   bash_escape "DB_NAME=${DB_NAME}" >> "${tmp_local_access_prod_env}"
   echo "# this is NOT the same DB user/password as the live app" >> "${tmp_local_access_prod_env}"
-  bash_escape "DB_APP_USER=${DB_LOCAL_ACCESS_USER}" >> "${tmp_local_access_prod_env}"
+  bash_escape "DB_USER=${DB_LOCAL_ACCESS_USER}" >> "${tmp_local_access_prod_env}"
   bash_escape "DB_PASSWORD=$(get_secret "${SKEY_DB_LOCAL_ACCESS_USER_PASSWORD_TEMP}")" >> "${tmp_local_access_prod_env}"
   echo "# assumes cloud-sql-proxy is proxying the prod DB locally over the configured port" >> "${tmp_local_access_prod_env}"
   bash_escape "DB_HOST=localhost" >> "${tmp_local_access_prod_env}"

--- a/deploy/gcloud_init_setup.sh
+++ b/deploy/gcloud_init_setup.sh
@@ -490,8 +490,9 @@ if [[ "${secrets_skip}" != "S" ]]; then
   }
   trap cleanup EXIT
 
-  bash_escape "IS_LOCAL_TO_PROD_DB_ACCESS_MODE=True" >> "${tmp_local_access_prod_env}"
-
+  echo "# this is NOT the production application env file BUT it does contain credentials for the production database. Handle appropriately"
+  bash_escape "IS_LOCAL=True" >> "${tmp_local_access_prod_env}"
+  
   bash_escape "DB_NAME=${DB_NAME}" >> "${tmp_local_access_prod_env}"
   echo "# this is NOT the same DB user/password as the live app" >> "${tmp_local_access_prod_env}"
   bash_escape "DB_APP_USER=${DB_LOCAL_ACCESS_USER}" >> "${tmp_local_access_prod_env}"

--- a/deploy/pulumi/package.json
+++ b/deploy/pulumi/package.json
@@ -13,9 +13,9 @@
   "scripts": {
     "precreate-uptime-monitoring": "npm ci && gcloud auth application-default login",
     "create-uptime-monitoring": "cd ./uptime_monitoring && (pulumi stack init uptime-monitoring || :) && (source ../../gcloud_env_vars.sh && pulumi up --stack uptime-monitoring)",
-    "postcreate-uptime-monitoring": "gcloud auth application-default revoke",
+    "postcreate-uptime-monitoring": "gcloud auth application-default revoke --quiet",
     "predestroy-uptime-monitoring": "npm ci && gcloud auth application-default login",
     "destroy-uptime-monitoring": "cd ./uptime_monitoring && pulumi destroy --stack uptime-monitoring && pulumi stack rm uptime-monitoring",
-    "postdestroy-uptime-monitoring": "gcloud auth application-default revoke"
+    "postdestroy-uptime-monitoring": "gcloud auth application-default revoke --quiet"
   }
 }

--- a/deploy/pulumi/package.json
+++ b/deploy/pulumi/package.json
@@ -13,7 +13,9 @@
   "scripts": {
     "precreate-uptime-monitoring": "npm ci && gcloud auth application-default login",
     "create-uptime-monitoring": "cd ./uptime_monitoring && (pulumi stack init uptime-monitoring || :) && (source ../../gcloud_env_vars.sh && pulumi up --stack uptime-monitoring)",
+    "postcreate-uptime-monitoring": "gcloud auth application-default revoke",
     "predestroy-uptime-monitoring": "npm ci && gcloud auth application-default login",
-    "destroy-uptime-monitoring": "cd ./uptime_monitoring && pulumi destroy --stack uptime-monitoring && pulumi stack rm uptime-monitoring"
+    "destroy-uptime-monitoring": "cd ./uptime_monitoring && pulumi destroy --stack uptime-monitoring && pulumi stack rm uptime-monitoring",
+    "postdestroy-uptime-monitoring": "gcloud auth application-default revoke"
   }
 }

--- a/server/.env.dev-public
+++ b/server/.env.dev-public
@@ -4,6 +4,8 @@
 # Note that .env.dev-secret will not exist when CI/CD runs your tests, your tests should never depend on 
 # secret values (e.g. instead of using a dev API key for a thrid-party service, mock the API for your tests)
 
+IS_LOCAL=True
+
 TEST_DB_NAME=cpho_test_db
 DB_NAME=cpho_dev_db
 DB_USER=cpho_db_user
@@ -13,10 +15,11 @@ DB_PORT=5432
 
 SECRET_KEY=abcdefg
 
-# dev settings
 ALLOWED_HOSTS=*
+
+# dev settings
+IS_DEV=True
 DEBUG=True
-IS_LOCAL_DEV=True
 
 # required for debug toolbar
 ENABLE_DEBUG_TOOLBAR=True

--- a/server/manage.py
+++ b/server/manage.py
@@ -4,6 +4,7 @@
 import os
 import sys
 
+from server.config_util import get_project_config
 from server.open_telemetry_util import instrument_app_for_open_telemetry
 
 

--- a/server/server/open_telemetry_util.py
+++ b/server/server/open_telemetry_util.py
@@ -26,10 +26,10 @@ from server.logging_util import add_metadata_to_all_logs_for_current_request
 
 def instrument_app_for_open_telemetry():
     config = get_project_config()
-    IS_LOCAL_DEV = config("IS_LOCAL_DEV", cast=bool, default=False)
+    IS_LOCAL = config("IS_LOCAL", cast=bool, default=False)
 
-    if IS_LOCAL_DEV:
-        project_id = "local-dev"
+    if IS_LOCAL:
+        project_id = "local"
 
         OUTPUT_TELEMETRY_TO_CONSOLE = config(
             "OUTPUT_TELEMETRY_TO_CONSOLE", cast=bool, default=False
@@ -52,9 +52,9 @@ def instrument_app_for_open_telemetry():
 
         span_exporter = CloudTraceSpanExporter(
             project_id=project_id,
-            # resource attributes aren't exported in GCP by default, as they aren't actually supported
-            # by Cloud Trace. This regex pattern is used to select resource attributes to covert and
-            # upload as regular attributes
+            # resource labels aren't exported in GCP by default, as the labels aren't actually supported
+            # by Cloud Trace. This regex pattern is used to select resource labels to pick out and convert
+            # to span attributes
             resource_regex=".*",
         )
 

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -35,9 +35,10 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 config = get_project_config()
 
 
-IS_LOCAL_DEV = config("IS_LOCAL_DEV", cast=bool, default=False)
+IS_LOCAL = config("IS_LOCAL", cast=bool, default=False)
+IS_DEV = config("IS_DEV", cast=bool, default=False)
 IS_RUNNING_TESTS = is_running_tests()
-if IS_LOCAL_DEV:
+if IS_LOCAL and IS_DEV:
     # For security, these test/dev settings should _never_ be used in production!
     DEBUG = config("DEBUG", default=False, cast=bool)
     ENABLE_DEBUG_TOOLBAR = DEBUG and config(
@@ -73,7 +74,7 @@ CORS_ALLOWED_ORIGINS = []
 CSRF_TRUSTED_ORIGINS = [f"https://{host}" for host in ALLOWED_HOSTS]
 
 # Prod only security settings
-if not IS_LOCAL_DEV:
+if not IS_DEV:
     # TODO these might be good to set, may be why an empty CSRF_TRUSTED_ORIGINS doesn't work, assuming
     # the cloud run load balancer/proxy might be downgrading our connection internally? Something to look in to,
     # likely requires corresponding changes to the load balancer's configuration though
@@ -99,7 +100,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 
 # whitenoise configuration
 if config(
-    "FORCE_WHITENOISE_PROD_BEHAVIOUR", cast=bool, default=(not IS_LOCAL_DEV)
+    "FORCE_WHITENOISE_PROD_BEHAVIOUR", cast=bool, default=(not IS_LOCAL)
 ):
     # requires staticfiles dir, run `./manage.py collectstatic --noinput` as needed!
     WHITENOISE_USE_FINDERS = False

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -34,10 +34,17 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 config = get_project_config()
 
-
 IS_LOCAL = config("IS_LOCAL", cast=bool, default=False)
 IS_DEV = config("IS_DEV", cast=bool, default=False)
 IS_RUNNING_TESTS = is_running_tests()
+
+if IS_LOCAL and not IS_DEV:
+    answer = input(
+        "WARNING: the current .env file is meant for connecting a LOCAL app to the PRODUCITON DB. Are you sure you want to target the production DB? [y/n]: "
+    )
+    if not answer or answer[0].lower() != "y":
+        exit(1)
+
 if IS_LOCAL and IS_DEV:
     # For security, these test/dev settings should _never_ be used in production!
     DEBUG = config("DEBUG", default=False, cast=bool)
@@ -53,7 +60,6 @@ if IS_LOCAL and IS_DEV:
         from . import monkey_patch_for_testing
 
         TEST_RUNNER = "tests.pytest_test_runner.PytestTestRunner"
-
 else:
     DEBUG = False
     ENABLE_DEBUG_TOOLBAR = False


### PR DESCRIPTION
Our DB has a private IP, accepting connections only inside the project's virtual private cloud. The Cloud Run app service connects to this with a Serverless VPC Connector. By default, we do not give the DB a public IP at all.

But, especially in the pre-prod phase, we still need to touch the Cloud SQL instance now and then. To enable this, I've added a script that wraps `cloud-sql-proxy` and adds a setup step that temporarily enables a public IP, allow listing only the external IP of the dev machine running the script, as well as an exit trap cleanup step that clears the allow list and disables the public IP. 

Using this script requires you to be logged in as (and re-oauth as, to generate a temporary credential file) a google account with sufficient IAM permissions for patching and connecting to the DB.

Note: this script just proxies the database to `localhost:6543`. The next step, of connecting a client to the DB and authenticating as a DB user, is up to the dev using it. That likely means having secret manager access to the DB credentials generate and saved during the `gcloud_init_setup.sh` script. 