### PR TITLE
Simple healthcheck route

### DIFF
--- a/server/server/open_telemetry_util.py
+++ b/server/server/open_telemetry_util.py
@@ -121,6 +121,16 @@ def instrument_app_for_open_telemetry():
         skip_dep_check=True,
     )
 
+    # Setting this env var is currently the only way to exclude URLs from tracing. It only read in
+    # during OpenTelemetry's initialization, which happens before the django app is installed,
+    # so we can't add to it dynamically or evenuse `django.urls.reverse` while constructing it,
+    # have to settle for hardcoding it in the .env (or setting a sensible default)
+    excluded_url_env_var_name = "OTEL_PYTHON_DJANGO_EXCLUDED_URLS"
+    excluded_urls = config(excluded_url_env_var_name, default="healthcheck")
+    # if this was set in an env file rather than an env var, need to lift it in to env vars
+    if not excluded_url_env_var_name in os.environ:
+        os.environ[excluded_url_env_var_name] = excluded_urls
+
     DjangoInstrumentor().instrument(
         tracer_provider=tracer_provider,
         meter_provider=None,  # TODO

--- a/server/server/urls.py
+++ b/server/server/urls.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
+from django.http import HttpResponse
 from django.urls import include, path, re_path
 
 from cpho.urls import (
@@ -22,6 +23,7 @@ urlpatterns = i18n_patterns(
     path("", include(cpho_urls)),
     prefix_default_language=False,
 ) + [
+    path("healthcheck/", lambda r: HttpResponse(), name="simple_healthcheck"),
     re_path("^$", RootView.as_view(), name="root"),
     *dev_routes,
 ]


### PR DESCRIPTION
A better route than `/` for the automatic GCP health checks to hit. Configured to be ignored by OpenTelemetry instrumentation too.

Related to #65.