### PR TITLE
Robots.txt, disalowing all bots

### DIFF
--- a/server/server/urls.py
+++ b/server/server/urls.py
@@ -24,6 +24,13 @@ urlpatterns = i18n_patterns(
     prefix_default_language=False,
 ) + [
     path("healthcheck/", lambda r: HttpResponse(), name="simple_healthcheck"),
+    path(
+        "robots.txt",
+        lambda r: HttpResponse(
+            "User-Agent: *\nDisallow: /", content_type="text/plain"
+        ),
+        name="robots",
+    ),
     re_path("^$", RootView.as_view(), name="root"),
     *dev_routes,
 ]


### PR DESCRIPTION
Quick and dirty. Not a site we want on search engines anyway, and this _might_ help with the noisy `django.core.exceptions.DisallowedHost` alerts (from legitimate sources at least, nefarious crawlers won't care, so the logging of those will probably need further tuning).