### PR TITLE
Prod DB backups on local connect

### DIFF
--- a/deploy/connect_cloud_sql_proxy.sh
+++ b/deploy/connect_cloud_sql_proxy.sh
@@ -32,7 +32,7 @@ trap cleanup EXIT
 
 echo ""
 echo "Starting DB backup. Note: manual backups are not deleted automatically, may require periodic cleanup"
-gcloud sql backups create --instance "${DB_INSTANCE_NAME}" --description "Triggered by connect_cloud_sql_proxy.sh"
+gcloud sql backups create --instance "${DB_INSTANCE_NAME}" --location ${PROJECT_REGION} --description "Triggered by connect_cloud_sql_proxy.sh"
 
 echo ""
 echo "Enabling public IP for database instance, configured to only accept traffic from your current external IP"

--- a/deploy/connect_cloud_sql_proxy.sh
+++ b/deploy/connect_cloud_sql_proxy.sh
@@ -31,8 +31,8 @@ function cleanup {
 trap cleanup EXIT
 
 echo ""
-echo "Starting DB backup (async). Note: manual backups are not deleted automatically, may require periodic cleanup"
-gcloud sql backups create --instance "${DB_INSTANCE_NAME}" --async --description "Triggered by connect_cloud_sql_proxy.sh"
+echo "Starting DB backup. Note: manual backups are not deleted automatically, may require periodic cleanup"
+gcloud sql backups create --instance "${DB_INSTANCE_NAME}" --description "Triggered by connect_cloud_sql_proxy.sh"
 
 echo ""
 echo "Enabling public IP for database instance, initially configured to refuse all public IP connections"
@@ -53,19 +53,6 @@ gcloud secrets versions access latest --secret "${SKEY_LOCAL_ACCESS_PROD_ENV_FIL
 echo ""
 echo "Getting temporary credentials for cloud-sql-proxy (oauth step)"
 gcloud auth application-default login
-
-echo ""
-echo "Waiting for async backup operation..."
-while [ true ]; do
-  running_backups=gcloud sql backups list --instance "${DB_INSTANCE_NAME}" --filter "status=RUNNING" --format "value(ID)"
-
-  if [ -z "${running_backups}" ]; then
-    echo "Backup complete"
-    break;
-  else
-    sleep 1
-  fi
-done
 
 echo ""
 echo "Connecting via cloud-sql-proxy. The database will be available via localhost at port ${LOCAL_ACCESS_DB_PORT}"

--- a/deploy/connect_cloud_sql_proxy.sh
+++ b/deploy/connect_cloud_sql_proxy.sh
@@ -35,16 +35,12 @@ echo "Starting DB backup. Note: manual backups are not deleted automatically, ma
 gcloud sql backups create --instance "${DB_INSTANCE_NAME}" --description "Triggered by connect_cloud_sql_proxy.sh"
 
 echo ""
-echo "Enabling public IP for database instance, initially configured to refuse all public IP connections"
-gcloud sql instances patch "${DB_INSTANCE_NAME}" --clear-authorized-networks --assign-ip --quiet
-
-echo ""
-echo "Adding current machine's external IP address to the DB's allow list"
+echo "Enabling public IP for database instance, configured to only accept traffic from your current external IP"
 # Your system doesn't usually know it's own external ip, need to send a packet out of your network, and then
 # ask whoever received it what they see it as (on the far side of your router, ISP, any other intermediate networks, etc)
 # ... so we're trusting that ipinfo.io doesn't lie to us. If we keep this approach long term, maybe we host our own IP reflector? 
-external_ip=$(curl https://ipinfo.io/ip)
-gcloud sql instances patch "${DB_INSTANCE_NAME}" --authorized-networks "${external_ip}" --quiet
+your_external_ip=$(curl https://ipinfo.io/ip)
+gcloud sql instances patch "${DB_INSTANCE_NAME}" --assign-ip --authorized-networks "${your_external_ip}"  --quiet
 
 echo ""
 echo "Getting a temporary env file that configures the local dev app for prod DB access, written to ${local_access_env_path}"

--- a/deploy/gcloud_init_setup.sh
+++ b/deploy/gcloud_init_setup.sh
@@ -352,6 +352,7 @@ if [[ "${sql_skip}" != "S" ]]; then
   gcloud beta sql instances create "${DB_INSTANCE_NAME}" \
     --project "${PROJECT_ID}" \
     --region "${PROJECT_REGION}" \
+    --backup-location "${PROJECT_REGION}" \
     --database-version "${DB_VERSION}" \
     --tier "${DB_TIER}" \
     --root-password $(get_secret "${SKEY_DB_ROOT_PASSWORD}") \


### PR DESCRIPTION
Forgot I'd meant to include backing up as a step in `connect_cloud_sql_proxy.sh`. Following up with that (also constraining the backups to a in-Canada region while I was at it).