### PR TITLE
add user-changelog, redirect to it from successful uploads

### DIFF
--- a/server/cpho/jinja2/base.jinja2
+++ b/server/cpho/jinja2/base.jinja2
@@ -97,6 +97,11 @@
                       <i class="bi bi-power"></i>
                       {{ tm("logout") }}
                     </a>
+                    <a class="dropdown-item"
+                       href="{{ url("user_scoped_changelog",args=[request.user.id]) }}">
+                      <i class="bi bi-file-diff"></i>
+                      {{ tdt("View your own changes") }}
+                    </a>
                     {% if respects_rule('can_manage_users') %}
                       <a class="dropdown-item" href="{{ url("manage_users") }}">
                         <i class="bi bi-people"></i>

--- a/server/cpho/jinja2/changelog/changelog_macros.jinja2
+++ b/server/cpho/jinja2/changelog/changelog_macros.jinja2
@@ -1,15 +1,13 @@
 {% from 'generic_macros.jinja2' import date_display %}
 
-{% macro changelog_table(edit_entries, show_model_type) %}
+{% macro changelog_table(edit_entries, show_model_type=True, show_user=True) %}
   <table style="width:100%" cellspacing="15" class="table table-striped">
     <thead class="thead-dark">
       <tr>
         <th>{{ tm("date") }}</th>
-        <th>{{ tm("author") }}</th>
+        {% if show_user %}<th>{{ tm("author") }}</th>{% endif %}
         <th>{{ tm("action") }}</th>
-        {% if show_model_type %}
-        <th>{{ tm("object_type") }}</th>
-        {% endif %}
+        {% if show_model_type %}<th>{{ tm("object_type") }}</th>{% endif %}
         <th>{{ tm("name") }}</th>
         <th>{{ tm("field") }}</th>
         <th>{{ tm("previous_change") }}</th>
@@ -21,33 +19,35 @@
         {% if not edit_entry.diffs %}
           <tr>
             <td>{{ date_display(edit_entry.version.instance.timestamp) }}</td>
-            <td>
-              {% if edit_entry.version.edited_by %}
-                {{ edit_entry.version.edited_by.username }}
-              {% else %}
-                {{ tdt("N/A") }}
-              {% endif %}
-            </td>
-            <td class='font-weight-bold'>{{ tdt("saved") }}</td>
-            {% if show_model_type %}
-            <td>{{ edit_entry.model_name }}</td>
+            {% if show_user %}
+              <td>
+                {% if edit_entry.version.edited_by %}
+                  {{ edit_entry.version.edited_by.username }}
+                {% else %}
+                  {{ tdt("N/A") }}
+                {% endif %}
+              </td>
             {% endif %}
+            <td class='font-weight-bold'>{{ tdt("saved") }}</td>
+            {% if show_model_type %}<td>{{ edit_entry.model_name }}</td>{% endif %}
             <td>{{ edit_entry.live_name }}</td>
             <td colspan="3">{{ tdt("no_change_detected_compared_to_previous_version") }}</td>
-           </tr>
+          </tr>
         {% endif %}
         {% for diff in edit_entry.diffs %}
           <tr>
             <td>{{ date_display(edit_entry.version.instance.timestamp) }}</td>
-            <td>
-              {% if edit_entry.version.edited_by %}
-                {{ edit_entry.version.edited_by.username }}
-              {% else %}
-                {{ tdt("N/A") }}
-              {% endif %}
-            </td>
+            {% if show_user %}
+              <td>
+                {% if edit_entry.version.edited_by %}
+                  {{ edit_entry.version.edited_by.username }}
+                {% else %}
+                  {{ tdt("N/A") }}
+                {% endif %}
+              </td>
+            {% endif %}
             <td class='font-weight-bold'>{{ diff.action }}</td>
-            <td>{{ edit_entry.model_name }}</td>
+            {% if show_model_type %}<td>{{ edit_entry.model_name }}</td>{% endif %}
             <td>{{ edit_entry.live_name }}</td>
             <td>
               {% if diff.field %}{{ diff.field.verbose_name }}{% endif %}

--- a/server/cpho/jinja2/changelog/indicator_scoped_changelog.jinja2
+++ b/server/cpho/jinja2/changelog/indicator_scoped_changelog.jinja2
@@ -17,6 +17,4 @@
   {{ changelog_table(edit_entries,False) }}
   {% include "changelog/_changelog_pagination.jinja2" %}
 
-
-
 {% endblock %}

--- a/server/cpho/jinja2/changelog/user_scoped_changelog.jinja2
+++ b/server/cpho/jinja2/changelog/user_scoped_changelog.jinja2
@@ -1,0 +1,20 @@
+{% extends 'base.jinja2' %}
+{% from 'changelog/changelog_macros.jinja2' import changelog_table %}
+
+
+{% block content %}
+
+  <a href="{{ url("list_indicators") }}" class="btn btn-secondary mb-2">{{ tdt("Back to indicators") }}</a>
+
+  <h1>{{ tdt("Changelog for user :") }} {{ user }}</h1>
+
+  <p>{{ tdt("These are all the indicator data changes your account has made") }}</p>
+
+  <style>{% include 'changelog/_changelog_styles.css' %}</style>
+
+  {{ changelog_table(edit_entries,True,False) }}
+  {% include "changelog/_changelog_pagination.jinja2" %}
+
+
+
+{% endblock %}

--- a/server/cpho/urls.py
+++ b/server/cpho/urls.py
@@ -90,6 +90,16 @@ urlpatterns = [
         name="indicator_scoped_changelog",
     ),
     path(
+        "users/<int:user_id>/changelog/",
+        views.UserScopedChangelog.as_view(),
+        name="user_scoped_changelog",
+    ),
+    path(
+        "users/<int:user_id>/changelog/<int:page_num>/",
+        views.UserScopedChangelog.as_view(),
+        name="user_scoped_changelog",
+    ),
+    path(
         "global-changelog/",
         views.GlobalChangelog.as_view(),
         name="global_changelog",

--- a/server/cpho/views/changelog.py
+++ b/server/cpho/views/changelog.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict
 
 from django import forms
-from django.core.exceptions import FieldDoesNotExist
+from django.core.exceptions import FieldDoesNotExist, PermissionDenied
 from django.views.generic import TemplateView
 
 from cpho import models
@@ -15,18 +15,17 @@ from versionator.changelog.consecutive_versions_fetcher import (
 from versionator.changelog.simple_changelog import create_simple_changelog
 
 
-class GlobalChangelog(TemplateView):
-    template_name = "changelog/global_changelog.jinja2"
+class ChangelogView(TemplateView):
+    def get_changelog_object(self):
+        raise NotImplementedError()
 
     def get_page_size(self):
         return 25
 
     def get_context_data(self, **kwargs):
         page_num = self.kwargs.get("page_num", 1)
-        changelog = create_simple_changelog(
-            changelog_models, page_size=self.get_page_size()
-        )
-        data = changelog.get_page(page_num)
+        changelog_object = self.get_changelog_object()
+        data = changelog_object.get_page(page_num)
 
         ctx = {
             "edit_entries": data["changelog_entries"],
@@ -44,52 +43,75 @@ class GlobalChangelog(TemplateView):
         return ctx
 
 
-def get_indicator_scoped_fetcher_class(indicator_id: int):
-    class IndicatorScopedFetcher(ConsecutiveVersionsFetcher):
-        def get_base_version_qs_for_single_model(self, indicator_datum_model):
-            if indicator_datum_model is not models.IndicatorDatum:
-                raise Exception("This changelog only supports IndicatorDatum")
+class GlobalChangelog(ChangelogView):
+    template_name = "changelog/global_changelog.jinja2"
 
-            history_model = indicator_datum_model._history_class
-            return history_model.objects.filter(
-                indicator_id=indicator_id
-            ).all()
-
-    return IndicatorScopedFetcher
+    def get_changelog_object(self):
+        return create_simple_changelog(
+            changelog_models, page_size=self.get_page_size()
+        )
 
 
-class IndicatorScopedChangelog(TemplateView):
+class IndicatorScopedChangelog(ChangelogView):
     template_name = "changelog/indicator_scoped_changelog.jinja2"
 
-    def get_page_size(self):
-        return 25
+    def get_changelog_object(self):
+        indicator_id = self.kwargs["indicator_id"]
 
-    def get_context_data(self, **kwargs):
-        page_num = self.kwargs.get("page_num", 1)
-        FetcherCls = get_indicator_scoped_fetcher_class(
-            self.kwargs["indicator_id"]
-        )
-        changelog = create_simple_changelog(
+        class IndicatorScopedFetcher(ConsecutiveVersionsFetcher):
+            def get_base_version_qs_for_single_model(
+                self, indicator_datum_model
+            ):
+                if indicator_datum_model is not models.IndicatorDatum:
+                    raise Exception(
+                        "This changelog only supports IndicatorDatum"
+                    )
+
+                history_model = indicator_datum_model._history_class
+                return history_model.objects.filter(
+                    indicator_id=indicator_id
+                ).all()
+
+        return create_simple_changelog(
             [models.IndicatorDatum],
-            fetcher_class=FetcherCls,
+            fetcher_class=IndicatorScopedFetcher,
             page_size=self.get_page_size(),
         )
-        data = changelog.get_page(page_num)
 
-        ctx = {
-            "edit_entries": data["changelog_entries"],
-            "has_next_page": data["has_next_page"],
-            "num_pages": data["num_pages"],
-            "page_num": page_num,
+    def get_context_data(self, **kwargs):
+        return {
+            **super().get_context_data(**kwargs),
             "indicator": models.Indicator.objects.get(
                 id=self.kwargs["indicator_id"]
             ),
         }
 
-        if page_num < data["num_pages"]:
-            ctx["next_page_num"] = page_num + 1
 
-        if page_num > 1:
-            ctx["prev_page_num"] = page_num - 1
+class UserScopedChangelog(ChangelogView):
+    template_name = "changelog/user_scoped_changelog.jinja2"
 
-        return ctx
+    def dispatch(self, request, *args, **kwargs):
+        if self.request.user.id != self.kwargs["user_id"]:
+            raise PermissionDenied()
+
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_changelog_object(self):
+        user_id = self.kwargs["user_id"]
+
+        class UserScopedFetcher(ConsecutiveVersionsFetcher):
+            def get_base_version_qs_for_single_model(self, live_model):
+                history_model = live_model._history_class
+                return history_model.objects.filter(edited_by_id=user_id).all()
+
+        return create_simple_changelog(
+            [models.Indicator, models.IndicatorDatum],
+            fetcher_class=UserScopedFetcher,
+            page_size=self.get_page_size(),
+        )
+
+    def get_context_data(self, **kwargs):
+        return {
+            **super().get_context_data(**kwargs),
+            "user": models.User.objects.get(id=self.kwargs["user_id"]),
+        }

--- a/server/cpho/views/upload_indicators.py
+++ b/server/cpho/views/upload_indicators.py
@@ -302,7 +302,7 @@ class UploadIndicator(MustPassAuthCheckMixin, FormView):
         return context
 
     def get_success_url(self):
-        return reverse("list_indicators")
+        return reverse("user_scoped_changelog", args=[self.request.user.id])
 
     def form_valid(self, form):
         form.save()


### PR DESCRIPTION
I thought it would be useful for users to see their changes when they upload a CSV. Unfortunately that is complex but what we can easily do is show them a changelog of all their changes EVER, and naturally the upload changes will be the first changes they see 
![Screenshot 2023-08-31 at 16 30 50](https://github.com/PHACDataHub/cpho-phase2/assets/7769215/157bf3c7-4f9b-4a4a-aaec-f9b7455bdcad)
