### PR TITLE
redirect unauthenticated users to login w/ ?next= param

### DIFF
--- a/server/cpho/translations.py
+++ b/server/cpho/translations.py
@@ -74,4 +74,8 @@ translation_entries = {
     "this_change": {
         "en": "This change",
     },
+    "please_login_to_see_page": {
+        "en": "Please login to see this page",
+        "fr": "Veuillez vous connecter pour voir cette page",
+    },
 }

--- a/server/server/middleware.py
+++ b/server/server/middleware.py
@@ -1,0 +1,45 @@
+import urllib
+
+from django.conf import settings
+from django.http.response import HttpResponseRedirect
+from django.views import View
+
+
+class MustBeLoggedInMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        return self.get_response(request)
+
+    def process_view(self, request, view_func, view_args, view_kwargs):
+        if getattr(view_func, "allow_unauthenticated", False):
+            return None
+
+        if request.user.is_authenticated:
+            return None
+
+        elif "/login" not in request.path.lower():
+            qs_params = dict(next=request.build_absolute_uri())
+            querystring = urllib.parse.urlencode(qs_params)
+            return HttpResponseRedirect(f"{settings.LOGIN_URL}?{querystring}")
+
+
+def allow_unauthenticated(view_func):
+    """
+    decoractor for function-based-views to exempt them from the must-be-logged-in middleware
+    """
+    view_func.allow_unauthenticated = True
+    return view_func
+
+
+class AllowUnauthenticatedMixin(View):
+    """
+    mixin for function-based-views to exempt them from the must-be-logged-in middleware
+    """
+
+    @classmethod
+    def as_view(cls, *args, **kwargs):
+        view = super().as_view(*args, **kwargs)
+        allow_unauthenticated(view)
+        return view

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -159,6 +159,7 @@ MIDDLEWARE = configure_middleware(
         "django.middleware.clickjacking.XFrameOptionsMiddleware",
         "versionator.middleware.WhodidMiddleware",
         "django_structlog.middlewares.RequestMiddleware",
+        "server.middleware.MustBeLoggedInMiddleware",
     ]
 )
 


### PR DESCRIPTION
If there are any exceptional views that don't require login, we'll have to tag them with the mixin or decorator