### PR TITLE
k8s pod and app process 1 to 1

### DIFF
--- a/k8s/application/server/deployment.yaml
+++ b/k8s/application/server/deployment.yaml
@@ -22,8 +22,9 @@ spec:
         # these are overrides for the default configuration of those injected proxy sidecars
         resources:
           requests:
-            cpu: 100m
-            memory: 128Mi
+            # Experiment: using the minimum pod resources https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#compute-class-min-max
+            cpu: 100m # + `server` container = 250m
+            memory: 128Mi # + `server` container = 512MiB
       - name: server
         securityContext:
           runAsUser: 5678
@@ -60,6 +61,7 @@ spec:
         resources:
           # Autopilot only considers requests (see https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#resource-limits)
           requests:
-            cpu: 250m
-            memory: 512Mi
+            # Experiment: using the minimum pod resources https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#compute-class-min-max
+            cpu: 150m # + `isito-proxy` container = 250m
+            memory: 384Mi # + `isito-proxy` container = 512MiB
 status: {}

--- a/k8s/application/server/deployment.yaml
+++ b/k8s/application/server/deployment.yaml
@@ -16,6 +16,14 @@ spec:
         app: server
     spec:
       containers:
+      - name: istio-proxy
+        image: auto
+        # istio-proxies are injected by anthos, see `istio.io/rev: asm-managed` in ../namespace.yaml
+        # these are overrides for the default configuration of those injected proxy sidecars
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
       - name: server
         securityContext:
           runAsUser: 5678

--- a/k8s/application/server/hpa.yaml
+++ b/k8s/application/server/hpa.yaml
@@ -6,7 +6,7 @@ metadata:
   name: server
   namespace: server
 spec:
-  maxReplicas: 4
+  maxReplicas: 8
   minReplicas: 1
   scaleTargetRef:
     apiVersion: apps/v1

--- a/server/gunicorn.conf.py
+++ b/server/gunicorn.conf.py
@@ -4,7 +4,6 @@ from server.open_telemetry_util import instrument_app_for_open_telemetry
 
 # See https://cloud.google.com/run/docs/tips/python#optimize_gunicorn
 
-# PORT env var is set by Cloud Run
 PORT = os.getenv("PORT", "8080")
 bind = [f"0.0.0.0:{PORT}"]
 

--- a/server/gunicorn.conf.py
+++ b/server/gunicorn.conf.py
@@ -8,32 +8,12 @@ from server.open_telemetry_util import instrument_app_for_open_telemetry
 PORT = os.getenv("PORT", "8080")
 bind = [f"0.0.0.0:{PORT}"]
 
-# Note: the generally recommended formula is `workers + threads = cpu_count * 2 + 1`, although gunicorn  describes this as "not overly scientific".
-# Cloud Run only has one vCPU by default, but Google doc Cloud Run gunicorn examples configure one worker and 8 threads consistently
-workers = 1  # increase this, and potentially adjust threads, if we ever configure a higher CPU count for Cloud Run
-threads = 4  # half of what GCP examples use, as each of our app process will use at least two threads (app thread + BatchSpanProcessor worker thread)
+# Experiment: trying k8s pods deployed with the minimal resources, and only one Django instance per container
+workers = 1
+threads = 1
 
-timeout = 0  # from the GCP docs: "timeout is set to 0 to disable the timeouts of the workers to allow Cloud Run to handle instance scaling."
-
-# Preloading is recommended by the GCP docs, with caveats; gotta be aware of what might be preloaded/resources used in the process/any gunicorn hooks used
-# Warning: preloading loads the app before gunicorn forks, meaning it's NOT compatible with situations where some initialization must occur in a post_fork hook
-# preload_app = True
-
-
-def post_fork(server, worker):
-    # When using OpenTelemetry's background process based BatchSpanProcessor, insturmentation must occur post worker forking. Pre-fork instrumentation
-    # would result in each app process trying to share the same BatchSpanProcessor worker thread, which would not be reliable.
-    # If NOT using BatchSpanProcessor (likely a bad idea, it's much more performant at run time) you can move instrumentation to wsgi.py and enable preload_app
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.settings")
-
-    worker.flush_telemetry_callback = instrument_app_for_open_telemetry()
-
-
-def worker_exit(server, worker):
-    worker.log.info(
-        f"Flushing telemetry for exiting worker (pid: {worker.pid})"
-    )
-    worker.flush_telemetry_callback()
-
+# From the GCP docs: "timeout is set to 0 to disable the timeouts of the workers to allow Cloud Run to handle instance scaling."
+# Assume it's of simillar benefit with GKE Autopilot, TODO: determine if that's true
+timeout = 0
 
 wsgi_app = "server.wsgi:application"

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -93,7 +93,7 @@ CSRF_TRUSTED_ORIGINS = [f"https://{host}" for host in ALLOWED_HOSTS]
 # Prod only security settings
 if not IS_DEV:
     # TODO these might be good to set, may be why an empty CSRF_TRUSTED_ORIGINS doesn't work, assuming
-    # the cloud run load balancer/proxy might be downgrading our connection internally? Something to look in to,
+    # the some load balancer/proxy might be downgrading our connection internally? Something to look in to,
     # likely requires corresponding changes to the load balancer's configuration though
     # SECURE_SSL_REDIRECT = True
     # SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTOCOL", "https")

--- a/server/server/wsgi.py
+++ b/server/server/wsgi.py
@@ -7,8 +7,13 @@ For more information on this file, see
 https://docs.djangoproject.com/en/3.2/howto/deployment/wsgi/
 """
 
-import os
+import atexit
 
 from django.core.wsgi import get_wsgi_application
+
+from server.open_telemetry_util import instrument_app_for_open_telemetry
+
+flush_telemetry_callback = instrument_app_for_open_telemetry()
+atexit.register(flush_telemetry_callback)
 
 application = get_wsgi_application()


### PR DESCRIPTION
Experimental k8s tuning, to see how the application performs when limited to one django server process per pod. Each pod is using the minimum pod-total resources for GKE Autopilot. 

This is probably not ideal, but I think it's worth trying just to learn more to inform future deployment tuning. We'll have to do some load testing against this once deployed, but there's plenty of tools for that.