### PR TITLE
Logo and wordmark

### DIFF
--- a/server/cpho/jinja2/base.jinja2
+++ b/server/cpho/jinja2/base.jinja2
@@ -149,13 +149,12 @@
     <div id="modal" class="modal fade" tabindex="-1">
       <div id="dialog" class="modal-dialog" hx-target="this"></div>
     </div>
-    <div id="footer-placeholder"></div>
     <footer class="d-print-none goc-footer bg-light">
       <div class="container">
         <div class="row">
           <div class="col"></div>
           <div class="col-auto">
-            <object type="image/svg+xml" tabindex="-1" role="img" data="{{ static("third_party/img/wmms-blk.svg") }}" aria-label="Symbol of the Government of Canada" style="height: 2rem"></object>
+            <object type="image/svg+xml" tabindex="-1" role="img" data="{{ static("third_party/img/wmms-blk.svg") }}" aria-label="Symbol of the Government of Canada" style="height: 2rem; margin: 1rem 0;"></object>
           </div>
         </div>
       </div>

--- a/server/cpho/jinja2/base.jinja2
+++ b/server/cpho/jinja2/base.jinja2
@@ -58,9 +58,8 @@
     {% block nav_container %}
       <nav class="navbar navbar-expand-md navbar-dark bg-dark">
         <div class="container">
-          {{ phac_aspc.phac_aspc_inline_svg("phac_aspc_helpers/phac_logos/" + ("en" if get_lang_code() == "en-ca" else "fr") + "__dark.svg") }}
+          {{ phac_aspc.phac_aspc_inline_svg("phac_aspc_helpers/phac_logos/" + ("en" if get_lang_code() == "en-ca" else "fr") + "__dark.svg", style="height: 2rem; padding-right: 2rem;") }}
           {% block available_apps %}{% endblock %}
-          {# <a class="nav-link text-white h1" href="{{ url('list_indicators') }}">{{ tdt("HoPiC")}}</a> #}
           <h1 class="nav-header">
             <a href="{{ url("list_indicators") }}"
                class="text-reset text-decoration-none">

--- a/server/cpho/jinja2/base.jinja2
+++ b/server/cpho/jinja2/base.jinja2
@@ -58,6 +58,7 @@
     {% block nav_container %}
       <nav class="navbar navbar-expand-md navbar-dark bg-dark">
         <div class="container">
+          {{ phac_aspc.phac_aspc_inline_svg("phac_aspc_helpers/phac_logos/" + ("en" if get_lang_code() == "en-ca" else "fr") + "__dark.svg") }}
           {% block available_apps %}{% endblock %}
           {# <a class="nav-link text-white h1" href="{{ url('list_indicators') }}">{{ tdt("HoPiC")}}</a> #}
           <h1 class="nav-header">

--- a/server/cpho/jinja_helpers.py
+++ b/server/cpho/jinja_helpers.py
@@ -53,6 +53,14 @@ def url_to_other_lang(context):
     return convert_url_other_lang(full_uri)
 
 
+def get_lang_code():
+    """
+    Provides the language code for the current language
+    """
+    current_lang = get_language()
+    return current_lang.lower()
+
+
 def get_other_lang_code():
     """
     Provides the language code for the other language (Ex. if current lang
@@ -159,6 +167,7 @@ def environment(**options):
             "list": list,
             "url": reverse,
             "url_to_other_lang": url_to_other_lang,
+            "get_lang_code": get_lang_code,
             "get_other_lang_code": get_other_lang_code,
             "get_other_lang": get_other_lang,
             "get_lang": get_language,

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,7 +1,7 @@
 django-debug-toolbar==3.8.1
 django-extensions==3.2.1
 django-htmx-autocomplete==0.8.2
-django-phac_aspc-helpers==1.0.5
+django-phac_aspc-helpers==1.1.1
 django-versionator==1.0.0
 Django==4.1.9
 Faker==15.1.1

--- a/server/static/cpho.css
+++ b/server/static/cpho.css
@@ -3,14 +3,7 @@ main {
 }
 
 footer {
-    position: static;
-    bottom: 0rem;
     width: 100%;
-    height: 3rem;
-}
-
-#footer-placeholder {
-    height: 3rem;
 }
 
 .navbar h1 {


### PR DESCRIPTION
Use PHAC logo from `django-phac_aspc-helpers`, tweak the wordmark/footer to look a little better. Closes #49.

![image](https://github.com/PHACDataHub/cpho-phase2/assets/11301919/8bd24a64-419d-4451-9858-a44e175186e0)


![image](https://github.com/PHACDataHub/cpho-phase2/assets/11301919/ae63a911-927f-41e6-a077-28b08cd07e30)
