### PR TITLE
Refactoring the CPU and Memory usage for Hopic Project

### DIFF
--- a/k8s/application/postgres-sql/cnpg-cm.yaml
+++ b/k8s/application/postgres-sql/cnpg-cm.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: cnpg-system
 data:
   INHERITED_LABELS: app
-  INHERITED_ANNOTATIONS: proxy.istio.io/*
+  INHERITED_ANNOTATIONS: proxy.istio.io/*, sidecar.istio.io/*

--- a/k8s/application/postgres-sql/kustomization.yaml
+++ b/k8s/application/postgres-sql/kustomization.yaml
@@ -15,3 +15,27 @@ patches:
       - op: add
         path: /metadata/labels/istio.io~1rev
         value: asm-managed
+  # Using the minimum pod resources https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#compute-class-min-max
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: cnpg-controller-manager
+      spec:
+        template:
+          spec:
+            containers:
+              - name: manager
+                resources:
+                  requests:
+                    cpu: 200m
+                    memory: 400Mi   
+              - name: istio-proxy
+                image: auto
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 112Mi   
+    target:
+      kind: Deployment
+      name: cnpg-controller-manager

--- a/k8s/application/postgres-sql/postgres-cluster.yaml
+++ b/k8s/application/postgres-sql/postgres-cluster.yaml
@@ -6,7 +6,12 @@ metadata:
   labels:
     app: postgres-cluster
   annotations:
+  # Sidecar injection for limits and resources https://cloud.google.com/service-mesh/docs/managed/provision-managed-anthos-service-mesh#custom-injection
     proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
+    sidecar.istio.io/proxyCPU: "50m"
+    sidecar.istio.io/proxyCPULimit: "50m"
+    sidecar.istio.io/proxyMemory: "100Mi"
+    sidecar.istio.io/proxyMemoryLimit: "100Mi"
 spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:15.4
   instances: 3

--- a/k8s/certmanager/kustomization.yaml
+++ b/k8s/certmanager/kustomization.yaml
@@ -111,3 +111,73 @@ patches:
       - op: add
         path: /metadata/labels/istio.io~1rev
         value: asm-managed
+  # Using the minimum pod resources https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#compute-class-min-max
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: cert-manager
+      spec:
+        template:
+          spec:
+            containers:
+              - name: cert-manager-controller
+                resources:
+                  requests:
+                    cpu: 200m
+                    memory: 400Mi   
+              - name: istio-proxy
+                image: auto
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 112Mi   
+    target:
+      kind: Deployment
+      name: "cert-manager"
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: cert-manager-cainjector
+      spec:
+        template:
+          spec:
+            containers:
+              - name: cert-manager-cainjector
+                resources:
+                  requests:
+                    cpu: 200m
+                    memory: 400Mi   
+              - name: istio-proxy
+                image: auto
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 112Mi   
+    target:
+      kind: Deployment
+      name: "cert-manager-cainjector"
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: cert-manager-webhook
+      spec:
+        template:
+          spec:
+            containers:
+              - name: cert-manager-webhook
+                resources:
+                  requests:
+                    cpu: 200m
+                    memory: 400Mi   
+              - name: istio-proxy
+                image: auto
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 112Mi   
+    target:
+      kind: Deployment
+      name: "cert-manager-webhook"

--- a/k8s/flux/kustomization.yaml
+++ b/k8s/flux/kustomization.yaml
@@ -16,3 +16,27 @@ patches:
       - op: add
         path: /metadata/labels/istio.io~1rev
         value: asm-managed
+# Using the minimum pod resources https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#compute-class-min-max
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: all
+      spec:
+        template:
+          spec:
+            containers:
+              - name: manager
+                resources:
+                  requests:
+                    cpu: 200m
+                    memory: 400Mi   
+              - name: istio-proxy
+                image: auto
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 112Mi   
+    target:
+      kind: Deployment
+      name: "(kustomize-controller|helm-controller|source-controller|image-reflector-controller|image-automation-controller)"


### PR DESCRIPTION
Issue: GCP Kubernetes Cluster requests 1CPU and 1GB Memory which lead to high deployment cost.
Fix: Each deployment, pod and cluster has been modified and limits are being added to the allocation to memory and cpu.  