### PR TITLE
Configure `readinessProbe` for server

### DIFF
--- a/k8s/server/django/deployment.yaml
+++ b/k8s/server/django/deployment.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         app: server
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
     spec:
       containers:
       - name: istio-proxy
@@ -66,4 +68,14 @@ spec:
             # Experiment: using the minimum pod resources https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#compute-class-min-max
             cpu: 150m # + `isito-proxy` container = 250m
             memory: 384Mi # + `isito-proxy` container = 512MiB
+        readinessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 8080
+            httpHeaders:
+              - name: Host
+                value: hopic-sdpac.k8s.phac-aspc.alpha.canada.ca
+          initialDelaySeconds: 35
+          periodSeconds: 10
+          timeoutSeconds: 3
 status: {}


### PR DESCRIPTION
Add readiness probe at `/healthcheck` endpoint.

Closes #139 