### PR TITLE
Chore: remove prod configuration references to the temporary k8s domain name

### DIFF
--- a/k8s/cert-manager/certificate.yaml
+++ b/k8s/cert-manager/certificate.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: istio-ingress
 spec:
   dnsNames:
-    - hopic-sdpac.k8s.phac-aspc.alpha.canada.ca
     - hopic-sdpac.phac-aspc.alpha.canada.ca
   issuerRef:
     kind: Issuer

--- a/k8s/server/django/deployment.yaml
+++ b/k8s/server/django/deployment.yaml
@@ -40,7 +40,7 @@ spec:
               name: django-secret-key
               key: secret-key
         - name: ALLOWED_HOSTS
-          value: "hopic-sdpac.k8s.phac-aspc.alpha.canada.ca,hopic-sdpac.phac-aspc.alpha.canada.ca,34.149.100.163,localhost,34.152.0.41"
+          value: "hopic-sdpac.phac-aspc.alpha.canada.ca,34.149.100.163,localhost,34.152.0.41"
         - name: SLACK_WEBHOOK_URL
           valueFrom:
             secretKeyRef:
@@ -93,7 +93,7 @@ spec:
             port: 8080
             httpHeaders:
             - name: Host
-              value: hopic-sdpac.k8s.phac-aspc.alpha.canada.ca
+              value: hopic-sdpac.phac-aspc.alpha.canada.ca
           initialDelaySeconds: 35
           periodSeconds: 10
           timeoutSeconds: 3


### PR DESCRIPTION
We stopped using that domain a few weeks back, had it redirecting to the current domain. Recently removed the domain from out alpha DNS repo, so any references to it are now fully deprecated.