### PR TITLE
use form.media instead of hardcoded link to generated static/ file

### DIFF
--- a/server/cpho/jinja2/indicators/_indicator_form.jinja2
+++ b/server/cpho/jinja2/indicators/_indicator_form.jinja2
@@ -1,9 +1,4 @@
-{# Scripts needed for CKEditor's rich text editor #}
-<script type="text/javascript"
-        src="{{ static ('ckeditor/ckeditor-init.js') }}"></script>
-<script type="text/javascript"
-        src="{{ static ('ckeditor/ckeditor/ckeditor.js') }}"></script>
-
+{{ form.media }}
 
 <form method="POST" action=".">
   {{ csrf_input }}


### PR DESCRIPTION
Using form.media renders the same script tags, but also adds an important attr to the first,
```html
<script src="/static/ckeditor/ckeditor-init.js" data-ckeditor-basepath="/static/ckeditor/ckeditor/" id="ckeditor-init-script"></script>
``` 