### PR TITLE
Update sync manifests

### DIFF
--- a/k8s/flux-system/gotk-sync.yaml
+++ b/k8s/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: "a11y-testing"
+    branch: "main"
   secretRef:
     name: flux-system
   url: ssh://git@github.com/PHACDataHub/cpho-phase2

--- a/k8s/server/sync.yaml
+++ b/k8s/server/sync.yaml
@@ -1,4 +1,17 @@
 ---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: "a11y-testing"
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  ref:
+    branch: "a11y-testing"
+  secretRef:
+    name: flux-system
+  url: ssh://git@github.com/PHACDataHub/cpho-phase2
+---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -10,7 +23,7 @@ spec:
   prune: true
   sourceRef:
     kind: GitRepository
-    name: flux-system
+    name: "a11y-testing"
   wait: true
   dependsOn:
     - name: cnpg-system
@@ -26,7 +39,7 @@ spec:
   prune: true
   sourceRef:
     kind: GitRepository
-    name: flux-system
+    name: "a11y-testing"
   dependsOn:
     - name: server-postgres
 ---
@@ -41,7 +54,7 @@ spec:
   prune: true
   sourceRef:
     kind: GitRepository
-    name: flux-system
+    name: "a11y-testing"
   dependsOn:
     - name: server-postgres
   decryption:
@@ -81,7 +94,7 @@ metadata:
 spec:
   sourceRef:
     kind: GitRepository
-    name: flux-system
+    name: "a11y-testing"
   interval: 5m
   update:
     strategy: Setters


### PR DESCRIPTION
tldr;
- add new `gitrepo` resource for `a11y-testing`
- update `server` namespace to reconcile against the new `gitrepo` resource
- point all other namespaces back to reconciling against the `main` branch

In the current scenario, all resources are reconciled against the `a11y-testing` branch. This makes it difficult to make  changes to the kubernetes specific components cause then we'd have to merge to `main` and then to `a11y-testing` to keep things clean.

This PR addresses the problem by adding a new `gitrepo` resource pointing to `a11y-testing` and updating the sync manifest in the `server/` directory to reconcile against the new `gitrepo` resource. In other words, this means all resources other than the ones in `server` namespace reconcile back to the `main` branch and all resources in `server` namespace reconcile to the `a11y-testing` branch.