### PR TITLE
Update SSO Secret

### DIFF
--- a/k8s/server/django/secrets.enc.yaml
+++ b/k8s/server/django/secrets.enc.yaml
@@ -15,8 +15,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-12-12T18:45:36Z"
-    mac: ENC[AES256_GCM,data:wHnK4XuiObfZG7CK2+bAZIIb2REYfpwluLn7hVwJx6+rtLb69H1aELAJpdD5WQAqB+7JhMjUPWBDsUYHBO7kkoL+PMSYDlJ0R70p+rHfCQgo2SpBBAh5BvYRuwmYH6hpQ+wsOQ7hvn2RSNpKUtQyYoSh2lThsF0IFDB1+Iobbh4=,iv:KMEem2wwdrE/+DOkE+uiz6b2B/IDImiR89XYGJa85/g=,tag:Sdq4HawBj/PLfJzVliZDCg==,type:str]
+    lastmodified: "2023-12-19T21:03:59Z"
+    mac: ENC[AES256_GCM,data:BRJcQP5Sh3qu79HGeEHcjGpl8EHr5n7XUTLKL97wVLNP3spYIvO+ZMwHDIQoRtCGJbEXQ7Fv1kQ7QZtRmDZ0QnqQjimpMI+DbxgCZ2WIN4J0WsMO5WprcxDcxWlv4Lp2/diz70mWM9LjCAfwk7jozFY3RToul39p8YrJf389Bwg=,iv:cW80U87J+keQY403gam/39BylEV7BO0wzqoSa+ItPBs=,tag:tGCFcFdpX5+yuSbqjyddRA==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.8.1
@@ -24,7 +24,7 @@ sops:
 apiVersion: v1
 data:
     client-id: ENC[AES256_GCM,data:64aUQ2UwOW8xq2ajiWbtyWi8h2egdqsVdaHIDWCrme+R/RXZHDwP2bZqlk5+hy/L,iv:cXVbvgvOoy4yZNdiqu4G6s5U1Lf6+9pyH8Qw83sd/ME=,tag:Sp4h135YCNDNA1qQXEYJJg==,type:str]
-    client-secret: ENC[AES256_GCM,data:bj8EdYVMslI/pjI+aVAE0AVscqqvBlaylcx91iLAlFHspPXy+9D3IgIgktpOl2dQizZk91oOgJs=,iv:XPcNs93dJYcW3AnqLWMoErUP4BNG5EhDZhmdoKbPPAk=,tag:2B63iD4Bby54mzD7s3inVQ==,type:str]
+    client-secret: ENC[AES256_GCM,data:+S5FY0240MmdzZBcZ4uEHi5ybQuyZjssSz1xmGI5f9CvpqLYfzfvEcPfU0ell7D5UiG7lNUQlB4=,iv:BRc3/03VFKhyDUwgvjfg5SPsxoyQX/R3AbvOV+mQyZg=,tag:3mDqhxy7oGEnfYrVk5GG+Q==,type:str]
     microsoft-tenant: ENC[AES256_GCM,data:URjlYy/5Xxo15WpbrrkLVb2qDgDiYHsZeFZgmJR7CO9O7oSIYzu+/YauBqfmoZo1,iv:1izXDyxhHwS0sBGsaFjEcWkTdFlRsnLN9QrU0EjvvJ4=,tag:DMMdilfBGAgPBBnB1U44Hw==,type:str]
 kind: Secret
 metadata:
@@ -40,8 +40,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-12-12T18:45:36Z"
-    mac: ENC[AES256_GCM,data:wHnK4XuiObfZG7CK2+bAZIIb2REYfpwluLn7hVwJx6+rtLb69H1aELAJpdD5WQAqB+7JhMjUPWBDsUYHBO7kkoL+PMSYDlJ0R70p+rHfCQgo2SpBBAh5BvYRuwmYH6hpQ+wsOQ7hvn2RSNpKUtQyYoSh2lThsF0IFDB1+Iobbh4=,iv:KMEem2wwdrE/+DOkE+uiz6b2B/IDImiR89XYGJa85/g=,tag:Sdq4HawBj/PLfJzVliZDCg==,type:str]
+    lastmodified: "2023-12-19T21:03:59Z"
+    mac: ENC[AES256_GCM,data:BRJcQP5Sh3qu79HGeEHcjGpl8EHr5n7XUTLKL97wVLNP3spYIvO+ZMwHDIQoRtCGJbEXQ7Fv1kQ7QZtRmDZ0QnqQjimpMI+DbxgCZ2WIN4J0WsMO5WprcxDcxWlv4Lp2/diz70mWM9LjCAfwk7jozFY3RToul39p8YrJf389Bwg=,iv:cW80U87J+keQY403gam/39BylEV7BO0wzqoSa+ItPBs=,tag:tGCFcFdpX5+yuSbqjyddRA==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.8.1
@@ -63,8 +63,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-12-12T18:45:36Z"
-    mac: ENC[AES256_GCM,data:wHnK4XuiObfZG7CK2+bAZIIb2REYfpwluLn7hVwJx6+rtLb69H1aELAJpdD5WQAqB+7JhMjUPWBDsUYHBO7kkoL+PMSYDlJ0R70p+rHfCQgo2SpBBAh5BvYRuwmYH6hpQ+wsOQ7hvn2RSNpKUtQyYoSh2lThsF0IFDB1+Iobbh4=,iv:KMEem2wwdrE/+DOkE+uiz6b2B/IDImiR89XYGJa85/g=,tag:Sdq4HawBj/PLfJzVliZDCg==,type:str]
+    lastmodified: "2023-12-19T21:03:59Z"
+    mac: ENC[AES256_GCM,data:BRJcQP5Sh3qu79HGeEHcjGpl8EHr5n7XUTLKL97wVLNP3spYIvO+ZMwHDIQoRtCGJbEXQ7Fv1kQ7QZtRmDZ0QnqQjimpMI+DbxgCZ2WIN4J0WsMO5WprcxDcxWlv4Lp2/diz70mWM9LjCAfwk7jozFY3RToul39p8YrJf389Bwg=,iv:cW80U87J+keQY403gam/39BylEV7BO0wzqoSa+ItPBs=,tag:tGCFcFdpX5+yuSbqjyddRA==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.8.1
@@ -86,8 +86,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-12-12T18:45:36Z"
-    mac: ENC[AES256_GCM,data:wHnK4XuiObfZG7CK2+bAZIIb2REYfpwluLn7hVwJx6+rtLb69H1aELAJpdD5WQAqB+7JhMjUPWBDsUYHBO7kkoL+PMSYDlJ0R70p+rHfCQgo2SpBBAh5BvYRuwmYH6hpQ+wsOQ7hvn2RSNpKUtQyYoSh2lThsF0IFDB1+Iobbh4=,iv:KMEem2wwdrE/+DOkE+uiz6b2B/IDImiR89XYGJa85/g=,tag:Sdq4HawBj/PLfJzVliZDCg==,type:str]
+    lastmodified: "2023-12-19T21:03:59Z"
+    mac: ENC[AES256_GCM,data:BRJcQP5Sh3qu79HGeEHcjGpl8EHr5n7XUTLKL97wVLNP3spYIvO+ZMwHDIQoRtCGJbEXQ7Fv1kQ7QZtRmDZ0QnqQjimpMI+DbxgCZ2WIN4J0WsMO5WprcxDcxWlv4Lp2/diz70mWM9LjCAfwk7jozFY3RToul39p8YrJf389Bwg=,iv:cW80U87J+keQY403gam/39BylEV7BO0wzqoSa+ItPBs=,tag:tGCFcFdpX5+yuSbqjyddRA==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.8.1


### PR DESCRIPTION
As mentioned in https://github.com/PHACDataHub/cpho-phase2/issues/159#issuecomment-1852400501, the deployment might require a restart to propagate the updated secret value.

Also, this branch needs to be further merged into `a11y-testing` due to https://github.com/PHACDataHub/cpho-phase2/pull/173.