### PR TITLE
Revert "Make a11y-testing, temporarily, the image deployment and cluster syncing branch"

### DIFF
--- a/deploy/gcloud_env_vars.sh
+++ b/deploy/gcloud_env_vars.sh
@@ -19,7 +19,7 @@ export PROJECT_ALPHA_SUB_DOMAIN=hopic-sdpac
 export BUILD_GITHUB_REPO_NAME=cpho-phase2
 export BUILD_GITHUB_REPO_OWNER=PHACDataHub
 
-export GITHUB_MAIN_BRANCH_NAME=a11y-testing
+export GITHUB_MAIN_BRANCH_NAME=main
 
 export TEST_COVERAGE_BUCKET_NAME=hopic-test-coverage-reports
 export TEST_COVERAGE_THRESHOLD=77.5 # set just below current coverage, consider increasing in time

--- a/k8s/flux-system/gotk-sync.yaml
+++ b/k8s/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: "a11y-testing"
+    branch: "main"
   secretRef:
     name: flux-system
   url: ssh://git@github.com/PHACDataHub/cpho-phase2

--- a/k8s/server/sync.yaml
+++ b/k8s/server/sync.yaml
@@ -66,7 +66,7 @@ metadata:
 spec:
   filterTags:
     extract: $ts
-    pattern: ^a11y-testing-[a-fA-F0-9]+-(?P<ts>.*)
+    pattern: ^main-[a-fA-F0-9]+-(?P<ts>.*)
   imageRepositoryRef:
     name: server
   policy:
@@ -89,11 +89,11 @@ spec:
   git:
     checkout:
       ref:
-        branch: "a11y-testing"
+        branch: "main"
     commit:
       author:
         name: fluxbot
         email: fluxcd@users.noreply.github.com
       messageTemplate: "[ci skip] {{range .Updated.Images}}{{println .}}{{end}}"
     push:
-      branch: "a11y-testing"
+      branch: "main"


### PR DESCRIPTION
tldr;
Reverts PHACDataHub/cpho-phase2#170 to attach the new k8s cluster (in noble-experimentation) to `main`.

The current cluster has been configured to sync against `a11y-testing` branch and we can tear it down once the accessibility testing has been completed.

Going forward, the plan is to utilize the new [noble-experimentation GCP project space](https://console.cloud.google.com/welcome?project=pht-01hhjj7tt0m) to stand up the infrastructure and use `main` branch as it's source of truth. That involves updating the GCP specific components in the manifests to point to the new space, which, will be done is subsequent PRs. [Here's](https://github.com/PHACDataHub/Wiki/wiki/Noble-(Experimentation)-Offering) some more info on noble-experimentation