### PR TITLE
Support SCRIPT_NAME env var, to enable "ephemeral" dev builds to be hosted from unique paths under a shared subdomain 

### DIFF
--- a/server/tests/test_jinja_helpers.py
+++ b/server/tests/test_jinja_helpers.py
@@ -1,0 +1,17 @@
+from cpho.jinja_helpers import convert_url_other_lang
+
+
+def test_convert_url_other_lang():
+    assert convert_url_other_lang("/some/path") == "/fr-ca/some/path"
+
+    assert (
+        convert_url_other_lang("/login?next=/some/path")
+        == "/fr-ca/login?next=/fr-ca/some/path"
+    )
+
+    assert convert_url_other_lang("/fr-ca/some/path") == "/some/path"
+
+    assert (
+        convert_url_other_lang("/fr-ca/login?next=/fr-ca/some/path")
+        == "/login?next=/some/path"
+    )

--- a/server/tests/test_jinja_helpers.py
+++ b/server/tests/test_jinja_helpers.py
@@ -1,17 +1,49 @@
+import os
+from unittest import mock
+
 from cpho.jinja_helpers import convert_url_other_lang
 
 
 def test_convert_url_other_lang():
-    assert convert_url_other_lang("/some/path") == "/fr-ca/some/path"
+    environ_without_script_name = {
+        k: v for k, v in os.environ.items() if k not in "SCRIPT_NAME"
+    }
+    with mock.patch.dict(os.environ, environ_without_script_name, clear=True):
+        assert convert_url_other_lang("/some/path") == "/fr-ca/some/path"
 
-    assert (
-        convert_url_other_lang("/login?next=/some/path")
-        == "/fr-ca/login?next=/fr-ca/some/path"
-    )
+        assert (
+            convert_url_other_lang("/login?next=/some/path")
+            == "/fr-ca/login?next=/fr-ca/some/path"
+        )
 
-    assert convert_url_other_lang("/fr-ca/some/path") == "/some/path"
+        assert convert_url_other_lang("/fr-ca/some/path") == "/some/path"
 
-    assert (
-        convert_url_other_lang("/fr-ca/login?next=/fr-ca/some/path")
-        == "/login?next=/some/path"
-    )
+        assert (
+            convert_url_other_lang("/fr-ca/login?next=/fr-ca/some/path")
+            == "/login?next=/some/path"
+        )
+
+
+def test_convert_url_other_lang_with_script_name_env_var():
+    with mock.patch.dict(os.environ, {"SCRIPT_NAME": "/test"}):
+        assert (
+            convert_url_other_lang("/test/some/path")
+            == "/test/fr-ca/some/path"
+        )
+
+        assert (
+            convert_url_other_lang("/test/login?next=/test/some/path")
+            == "/test/fr-ca/login?next=/test/fr-ca/some/path"
+        )
+
+        assert (
+            convert_url_other_lang("/test/fr-ca/some/path")
+            == "/test/some/path"
+        )
+
+        assert (
+            convert_url_other_lang(
+                "/test/fr-ca/login?next=/test/fr-ca/some/path"
+            )
+            == "/test/login?next=/test/some/path"
+        )


### PR DESCRIPTION
Not super well documented on Django's end, and a little wonky, but this is a common feature of many servers/server gateway interfaces and it's Django's prescribed method for hosting a Django app from a sub-resource (path) under a domain. I've left a beefy comment in settings.py to cover the weirder aspects. The env var will only be set in the ephemeral deployments, so none of this impacts prod or local dev.

Well, one caveat to that. Code that modifies the path directly (notably and possibly only `convert_url_other_lang`) needs to understand and account for `SCRIPT_NAME` path components, or else there will be ephemeral deployment specific bugs. Not a big deal though, as I see it. Forgetting to account for it won't impact prod, worst case it's just an obscure foot gun for the obscure ephemeral dev builds.