### PR TITLE
Configure server for noble

### DIFF
--- a/k8s/cnpg-system/cnpg-cm.yaml
+++ b/k8s/cnpg-system/cnpg-cm.yaml
@@ -4,5 +4,5 @@ metadata:
   name: cnpg-controller-manager-config
   namespace: cnpg-system
 data:
-  INHERITED_LABELS: app
+  INHERITED_LABELS: app, branch
   INHERITED_ANNOTATIONS: proxy.istio.io/*, sidecar.istio.io/*

--- a/k8s/cnpg-system/cnpg-crds.yaml
+++ b/k8s/cnpg-system/cnpg-crds.yaml
@@ -1,4 +1,5 @@
-# https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.20/releases/cnpg-1.20.2.yaml
+# https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.22/releases/cnpg-1.22.1.yaml
+# See https://cloudnative-pg.io/documentation/1.22/installation_upgrade/ for installation details
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -10,7 +11,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: backups.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -27,6 +28,9 @@ spec:
       type: date
     - jsonPath: .spec.cluster.name
       name: Cluster
+      type: string
+    - jsonPath: .spec.method
+      name: Method
       type: string
     - jsonPath: .status.phase
       name: Phase
@@ -64,6 +68,46 @@ spec:
                 required:
                 - name
                 type: object
+              method:
+                default: barmanObjectStore
+                description: 'The backup method to be used, possible options are `barmanObjectStore`
+                  and `volumeSnapshot`. Defaults to: `barmanObjectStore`.'
+                enum:
+                - barmanObjectStore
+                - volumeSnapshot
+                type: string
+              online:
+                description: Whether the default type of backup with volume snapshots
+                  is online/hot (`true`, default) or offline/cold (`false`) Overrides
+                  the default setting specified in the cluster field '.spec.backup.volumeSnapshot.online'
+                type: boolean
+              onlineConfiguration:
+                description: Configuration parameters to control the online/hot backup
+                  with volume snapshots Overrides the default settings specified in
+                  the cluster '.backup.volumeSnapshot.onlineConfiguration' stanza
+                properties:
+                  immediateCheckpoint:
+                    description: Control whether the I/O workload for the backup initial
+                      checkpoint will be limited, according to the `checkpoint_completion_target`
+                      setting on the PostgreSQL server. If set to true, an immediate
+                      checkpoint will be used, meaning PostgreSQL will complete the
+                      checkpoint as soon as possible. `false` by default.
+                    type: boolean
+                  waitForArchive:
+                    default: true
+                    description: If false, the function will return immediately after
+                      the backup is completed, without waiting for WAL to be archived.
+                      This behavior is only useful with backup software that independently
+                      monitors WAL archiving. Otherwise, WAL required to make the
+                      backup consistent might be missing and make the backup useless.
+                      By default, or when this parameter is true, pg_backup_stop will
+                      wait for WAL to be archived when archiving is enabled. On a
+                      standby, this means that it will wait only when archive_mode
+                      = always. If write activity on the primary is low, it may be
+                      useful to run pg_switch_wal on the primary in order to trigger
+                      an immediate segment switch.
+                    type: boolean
+                type: object
               target:
                 description: The policy to decide which instance should perform this
                   backup. If empty, it defaults to `cluster.spec.backup.target`. Available
@@ -74,6 +118,8 @@ spec:
                 - primary
                 - prefer-standby
                 type: string
+            required:
+            - cluster
             type: object
           status:
             description: 'Most recently observed status of the backup. This data may
@@ -143,6 +189,11 @@ spec:
                 type: object
               backupId:
                 description: The ID of the Barman backup
+                type: string
+              backupLabelFile:
+                description: Backup label file content as returned by Postgres in
+                  case of online (hot) backups
+                format: byte
                 type: string
               backupName:
                 description: The Name of the Barman backup
@@ -229,6 +280,13 @@ spec:
                     description: The pod name
                     type: string
                 type: object
+              method:
+                description: The backup method being used
+                type: string
+              online:
+                description: Whether the backup was online/hot (`true`) or offline/cold
+                  (`false`)
+                type: boolean
               phase:
                 description: The last backup status
                 type: string
@@ -297,6 +355,33 @@ spec:
                 description: The server name on S3, the cluster name is used if this
                   parameter is omitted
                 type: string
+              snapshotBackupStatus:
+                description: Status of the volumeSnapshot backup
+                properties:
+                  elements:
+                    description: The elements list, populated with the gathered volume
+                      snapshots
+                    items:
+                      description: BackupSnapshotElementStatus is a volume snapshot
+                        that is part of a volume snapshot method backup
+                      properties:
+                        name:
+                          description: Name is the snapshot resource name
+                          type: string
+                        tablespaceName:
+                          description: TablespaceName is the name of the snapshotted
+                            tablespace. Only set when type is PG_TABLESPACE
+                          type: string
+                        type:
+                          description: Type is tho role of the snapshot in the cluster,
+                            such as PG_DATA, PG_WAL and PG_TABLESPACE
+                          type: string
+                      required:
+                      - name
+                      - type
+                      type: object
+                    type: array
+                type: object
               startedAt:
                 description: When the backup was started
                 format: date-time
@@ -305,7 +390,15 @@ spec:
                 description: When the backup was terminated
                 format: date-time
                 type: string
+              tablespaceMapFile:
+                description: Tablespace map file content as returned by Postgres in
+                  case of online (hot) backups
+                format: byte
+                type: string
             type: object
+        required:
+        - metadata
+        - spec
         type: object
     served: true
     storage: true
@@ -316,7 +409,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: clusters.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -1540,7 +1633,8 @@ spec:
                     description: RetentionPolicy is the retention policy to be used
                       for backups and WALs (i.e. '60d'). The retention policy is expressed
                       in the form of `XXu` where `XX` is a positive integer and `u`
-                      is in `[dwm]` - days, weeks, months.
+                      is in `[dwm]` - days, weeks, months. It's currently only applicable
+                      when using the BarmanObjectStore method.
                     pattern: ^[1-9][0-9]*[dwm]$
                     type: string
                   target:
@@ -1554,6 +1648,85 @@ spec:
                     - primary
                     - prefer-standby
                     type: string
+                  volumeSnapshot:
+                    description: VolumeSnapshot provides the configuration for the
+                      execution of volume snapshot backups.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations key-value pairs that will be added
+                          to .metadata.annotations snapshot resources.
+                        type: object
+                      className:
+                        description: ClassName specifies the Snapshot Class to be
+                          used for PG_DATA PersistentVolumeClaim. It is the default
+                          class for the other types if no specific class is present
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels are key-value pairs that will be added
+                          to .metadata.labels snapshot resources.
+                        type: object
+                      online:
+                        default: true
+                        description: Whether the default type of backup with volume
+                          snapshots is online/hot (`true`, default) or offline/cold
+                          (`false`)
+                        type: boolean
+                      onlineConfiguration:
+                        default:
+                          immediateCheckpoint: false
+                          waitForArchive: true
+                        description: Configuration parameters to control the online/hot
+                          backup with volume snapshots
+                        properties:
+                          immediateCheckpoint:
+                            description: Control whether the I/O workload for the
+                              backup initial checkpoint will be limited, according
+                              to the `checkpoint_completion_target` setting on the
+                              PostgreSQL server. If set to true, an immediate checkpoint
+                              will be used, meaning PostgreSQL will complete the checkpoint
+                              as soon as possible. `false` by default.
+                            type: boolean
+                          waitForArchive:
+                            default: true
+                            description: If false, the function will return immediately
+                              after the backup is completed, without waiting for WAL
+                              to be archived. This behavior is only useful with backup
+                              software that independently monitors WAL archiving.
+                              Otherwise, WAL required to make the backup consistent
+                              might be missing and make the backup useless. By default,
+                              or when this parameter is true, pg_backup_stop will
+                              wait for WAL to be archived when archiving is enabled.
+                              On a standby, this means that it will wait only when
+                              archive_mode = always. If write activity on the primary
+                              is low, it may be useful to run pg_switch_wal on the
+                              primary in order to trigger an immediate segment switch.
+                            type: boolean
+                        type: object
+                      snapshotOwnerReference:
+                        default: none
+                        description: SnapshotOwnerReference indicates the type of
+                          owner reference the snapshot should have
+                        enum:
+                        - none
+                        - cluster
+                        - backup
+                        type: string
+                      tablespaceClassName:
+                        additionalProperties:
+                          type: string
+                        description: TablespaceClassName specifies the Snapshot Class
+                          to be used for the tablespaces. defaults to the PGDATA Snapshot
+                          Class, if set
+                        type: object
+                      walClassName:
+                        description: WalClassName specifies the Snapshot Class to
+                          be used for the PG_WAL PersistentVolumeClaim.
+                        type: string
+                    type: object
                 type: object
               bootstrap:
                 description: Instructions to bootstrap this cluster
@@ -1597,7 +1770,6 @@ spec:
                               type: string
                             type: array
                           schemaOnly:
-                            default: false
                             description: 'When set to true, only the `pre-data` and
                               `post-data` sections of `pg_restore` are invoked, avoiding
                               data import. Default: `false`.'
@@ -1860,7 +2032,7 @@ spec:
                         description: The external cluster whose backup we will restore.
                           This is also used as the name of the folder under which
                           the backup is stored, so it must be set to the name of the
-                          source cluster Mutually exclusive with `backup` and `volumeSnapshots`.
+                          source cluster Mutually exclusive with `backup`.
                         type: string
                       volumeSnapshots:
                         description: The static PVC data source(s) from which to initiate
@@ -1869,7 +2041,7 @@ spec:
                           PVC group, compatible with CloudNativePG, and taken with
                           a cold backup copy on a fenced Postgres instance (limitation
                           which will be removed in the future when online backup will
-                          be implemented). Mutually exclusive with `backup` and `source`.
+                          be implemented). Mutually exclusive with `backup`.
                         properties:
                           storage:
                             description: Configuration of the storage of the instances
@@ -1891,6 +2063,34 @@ spec:
                             - name
                             type: object
                             x-kubernetes-map-type: atomic
+                          tablespaceStorage:
+                            additionalProperties:
+                              description: TypedLocalObjectReference contains enough
+                                information to let you locate the typed referenced
+                                object inside the same namespace.
+                              properties:
+                                apiGroup:
+                                  description: APIGroup is the group for the resource
+                                    being referenced. If APIGroup is not specified,
+                                    the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            description: Configuration of the storage for PostgreSQL
+                              tablespaces
+                            type: object
                           walStorage:
                             description: Configuration of the storage for PostgreSQL
                               WAL (Write-Ahead Log)
@@ -1964,13 +2164,13 @@ spec:
                 description: Description of this PostgreSQL cluster
                 type: string
               enableSuperuserAccess:
-                default: true
+                default: false
                 description: When this option is enabled, the operator will use the
                   `SuperuserSecret` to update the `postgres` user password (if the
                   secret is not present, the operator will automatically create one).
                   When this option is disabled, the operator will ignore the `SuperuserSecret`
                   content, delete it when automatically created, and then blank the
-                  password of the `postgres` user by setting it to `NULL`. Enabled
+                  password of the `postgres` user by setting it to `NULL`. Disabled
                   by default.
                 type: boolean
               env:
@@ -2119,6 +2319,274 @@ spec:
                       x-kubernetes-map-type: atomic
                   type: object
                 type: array
+              ephemeralVolumeSource:
+                description: EphemeralVolumeSource allows the user to configure the
+                  source of ephemeral volumes.
+                properties:
+                  volumeClaimTemplate:
+                    description: "Will be used to create a stand-alone PVC to provision
+                      the volume. The pod in which this EphemeralVolumeSource is embedded
+                      will be the owner of the PVC, i.e. the PVC will be deleted together
+                      with the pod.  The name of the PVC will be `<pod name>-<volume
+                      name>` where `<volume name>` is the name from the `PodSpec.Volumes`
+                      array entry. Pod validation will reject the pod if the concatenated
+                      name is not valid for a PVC (for example, too long). \n An existing
+                      PVC with that name that is not owned by the pod will *not* be
+                      used for the pod to avoid using an unrelated volume by mistake.
+                      Starting the pod is then blocked until the unrelated PVC is
+                      removed. If such a pre-created PVC is meant to be used by the
+                      pod, the PVC has to updated with an owner reference to the pod
+                      once the pod exists. Normally this should not be necessary,
+                      but it may be useful when manually reconstructing a broken cluster.
+                      \n This field is read-only and no changes will be made by Kubernetes
+                      to the PVC after it has been created. \n Required, must not
+                      be nil."
+                    properties:
+                      metadata:
+                        description: May contain labels and annotations that will
+                          be copied into the PVC when creating it. No other fields
+                          are allowed and will be rejected during validation.
+                        type: object
+                      spec:
+                        description: The specification for the PersistentVolumeClaim.
+                          The entire content is copied unchanged into the PVC that
+                          gets created from this template. The same fields as in a
+                          PersistentVolumeClaim are also valid here.
+                        properties:
+                          accessModes:
+                            description: 'accessModes contains the desired access
+                              modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                            items:
+                              type: string
+                            type: array
+                          dataSource:
+                            description: 'dataSource field can be used to specify
+                              either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                              * An existing PVC (PersistentVolumeClaim) If the provisioner
+                              or an external controller can support the specified
+                              data source, it will create a new volume based on the
+                              contents of the specified data source. When the AnyVolumeDataSource
+                              feature gate is enabled, dataSource contents will be
+                              copied to dataSourceRef, and dataSourceRef contents
+                              will be copied to dataSource when dataSourceRef.namespace
+                              is not specified. If the namespace is specified, then
+                              dataSourceRef will not be copied to dataSource.'
+                            properties:
+                              apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced. If APIGroup is not specified,
+                                  the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSourceRef:
+                            description: 'dataSourceRef specifies the object from
+                              which to populate the volume with data, if a non-empty
+                              volume is desired. This may be any object from a non-empty
+                              API group (non core object) or a PersistentVolumeClaim
+                              object. When this field is specified, volume binding
+                              will only succeed if the type of the specified object
+                              matches some installed volume populator or dynamic provisioner.
+                              This field will replace the functionality of the dataSource
+                              field and as such if both fields are non-empty, they
+                              must have the same value. For backwards compatibility,
+                              when namespace isn''t specified in dataSourceRef, both
+                              fields (dataSource and dataSourceRef) will be set to
+                              the same value automatically if one of them is empty
+                              and the other is non-empty. When namespace is specified
+                              in dataSourceRef, dataSource isn''t set to the same
+                              value and must be empty. There are three important differences
+                              between dataSource and dataSourceRef: * While dataSource
+                              only allows two specific types of objects, dataSourceRef
+                              allows any non-core object, as well as PersistentVolumeClaim
+                              objects. * While dataSource ignores disallowed values
+                              (dropping them), dataSourceRef preserves all values,
+                              and generates an error if a disallowed value is specified.
+                              * While dataSource only allows local objects, dataSourceRef
+                              allows objects in any namespaces. (Beta) Using this
+                              field requires the AnyVolumeDataSource feature gate
+                              to be enabled. (Alpha) Using the namespace field of
+                              dataSourceRef requires the CrossNamespaceVolumeDataSource
+                              feature gate to be enabled.'
+                            properties:
+                              apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced. If APIGroup is not specified,
+                                  the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                              namespace:
+                                description: Namespace is the namespace of resource
+                                  being referenced Note that when a namespace is specified,
+                                  a gateway.networking.k8s.io/ReferenceGrant object
+                                  is required in the referent namespace to allow that
+                                  namespace's owner to accept the reference. See the
+                                  ReferenceGrant documentation for details. (Alpha)
+                                  This field requires the CrossNamespaceVolumeDataSource
+                                  feature gate to be enabled.
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          resources:
+                            description: 'resources represents the minimum resources
+                              the volume should have. If RecoverVolumeExpansionFailure
+                              feature is enabled users are allowed to specify resource
+                              requirements that are lower than previous value but
+                              must still be higher than capacity recorded in the status
+                              field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                            properties:
+                              claims:
+                                description: "Claims lists the names of resources,
+                                  defined in spec.resourceClaims, that are used by
+                                  this container. \n This is an alpha field and requires
+                                  enabling the DynamicResourceAllocation feature gate.
+                                  \n This field is immutable. It can only be set for
+                                  containers."
+                                items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: Name must match the name of one
+                                        entry in pod.spec.resourceClaims of the Pod
+                                        where this field is used. It makes that resource
+                                        available inside a container.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. Requests cannot exceed Limits. More info:
+                                  https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                            type: object
+                          selector:
+                            description: selector is a label query over volumes to
+                              consider for binding.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          storageClassName:
+                            description: 'storageClassName is the name of the StorageClass
+                              required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                            type: string
+                          volumeMode:
+                            description: volumeMode defines what type of volume is
+                              required by the claim. Value of Filesystem is implied
+                              when not included in claim spec.
+                            type: string
+                          volumeName:
+                            description: volumeName is the binding reference to the
+                              PersistentVolume backing this claim.
+                            type: string
+                        type: object
+                    required:
+                    - spec
+                    type: object
+                type: object
+              ephemeralVolumesSizeLimit:
+                description: EphemeralVolumesSizeLimit allows the user to set the
+                  limits for the ephemeral volumes
+                properties:
+                  shm:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Shm is the size limit of the shared memory volume
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  temporaryData:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: TemporaryData is the size limit of the temporary
+                      data volume
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                type: object
               externalClusters:
                 description: The list of external clusters which are used in the configuration
                 items:
@@ -2407,7 +2875,13 @@ spec:
                       type: string
                     password:
                       description: The reference to the password to be used to connect
-                        to the server
+                        to the server. If a password is provided, CloudNativePG creates
+                        a PostgreSQL passfile at `/controller/external/NAME/pass`
+                        (where "NAME" is the cluster's name). This passfile is automatically
+                        referenced in the connection string when establishing a connection
+                        to the remote PostgreSQL server from the current PostgreSQL
+                        `Cluster`. This ensures secure and efficient password management
+                        for external clusters.
                       properties:
                         key:
                           description: The key of the secret to select from.  Must
@@ -2721,6 +3195,156 @@ spec:
                     default: false
                     description: Enable or disable the `PodMonitor`
                     type: boolean
+                  podMonitorMetricRelabelings:
+                    description: The list of metric relabelings for the `PodMonitor`.
+                      Applied to samples before ingestion.
+                    items:
+                      description: "RelabelConfig allows dynamic rewriting of the
+                        label set for targets, alerts, scraped samples and remote
+                        write samples. \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
+                      properties:
+                        action:
+                          default: replace
+                          description: "Action to perform based on the regex matching.
+                            \n `Uppercase` and `Lowercase` actions require Prometheus
+                            >= v2.36.0. `DropEqual` and `KeepEqual` actions require
+                            Prometheus >= v2.41.0. \n Default: \"Replace\""
+                          enum:
+                          - replace
+                          - Replace
+                          - keep
+                          - Keep
+                          - drop
+                          - Drop
+                          - hashmod
+                          - HashMod
+                          - labelmap
+                          - LabelMap
+                          - labeldrop
+                          - LabelDrop
+                          - labelkeep
+                          - LabelKeep
+                          - lowercase
+                          - Lowercase
+                          - uppercase
+                          - Uppercase
+                          - keepequal
+                          - KeepEqual
+                          - dropequal
+                          - DropEqual
+                          type: string
+                        modulus:
+                          description: "Modulus to take of the hash of the source
+                            label values. \n Only applicable when the action is `HashMod`."
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched.
+                          type: string
+                        replacement:
+                          description: "Replacement value against which a Replace
+                            action is performed if the regular expression matches.
+                            \n Regex capture groups are available."
+                          type: string
+                        separator:
+                          description: Separator is the string between concatenated
+                            SourceLabels.
+                          type: string
+                        sourceLabels:
+                          description: The source labels select values from existing
+                            labels. Their content is concatenated using the configured
+                            Separator and matched against the configured regular expression.
+                          items:
+                            description: LabelName is a valid Prometheus label name
+                              which may only contain ASCII letters, numbers, as well
+                              as underscores.
+                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: "Label to which the resulting string is written
+                            in a replacement. \n It is mandatory for `Replace`, `HashMod`,
+                            `Lowercase`, `Uppercase`, `KeepEqual` and `DropEqual`
+                            actions. \n Regex capture groups are available."
+                          type: string
+                      type: object
+                    type: array
+                  podMonitorRelabelings:
+                    description: The list of relabelings for the `PodMonitor`. Applied
+                      to samples before scraping.
+                    items:
+                      description: "RelabelConfig allows dynamic rewriting of the
+                        label set for targets, alerts, scraped samples and remote
+                        write samples. \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
+                      properties:
+                        action:
+                          default: replace
+                          description: "Action to perform based on the regex matching.
+                            \n `Uppercase` and `Lowercase` actions require Prometheus
+                            >= v2.36.0. `DropEqual` and `KeepEqual` actions require
+                            Prometheus >= v2.41.0. \n Default: \"Replace\""
+                          enum:
+                          - replace
+                          - Replace
+                          - keep
+                          - Keep
+                          - drop
+                          - Drop
+                          - hashmod
+                          - HashMod
+                          - labelmap
+                          - LabelMap
+                          - labeldrop
+                          - LabelDrop
+                          - labelkeep
+                          - LabelKeep
+                          - lowercase
+                          - Lowercase
+                          - uppercase
+                          - Uppercase
+                          - keepequal
+                          - KeepEqual
+                          - dropequal
+                          - DropEqual
+                          type: string
+                        modulus:
+                          description: "Modulus to take of the hash of the source
+                            label values. \n Only applicable when the action is `HashMod`."
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched.
+                          type: string
+                        replacement:
+                          description: "Replacement value against which a Replace
+                            action is performed if the regular expression matches.
+                            \n Regex capture groups are available."
+                          type: string
+                        separator:
+                          description: Separator is the string between concatenated
+                            SourceLabels.
+                          type: string
+                        sourceLabels:
+                          description: The source labels select values from existing
+                            labels. Their content is concatenated using the configured
+                            Separator and matched against the configured regular expression.
+                          items:
+                            description: LabelName is a valid Prometheus label name
+                              which may only contain ASCII letters, numbers, as well
+                              as underscores.
+                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: "Label to which the resulting string is written
+                            in a replacement. \n It is mandatory for `Replace`, `HashMod`,
+                            `Lowercase`, `Uppercase`, `KeepEqual` and `DropEqual`
+                            actions. \n Regex capture groups are available."
+                          type: string
+                      type: object
+                    type: array
                 type: object
               nodeMaintenanceWindow:
                 description: Define a maintenance window for the Kubernetes nodes
@@ -2734,8 +3358,6 @@ spec:
                     description: Reuse the existing PVC (wait for the node to come
                       up again) or not (recreate it elsewhere - when `instances` >1)
                     type: boolean
-                required:
-                - inProgress
                 type: object
               postgresGID:
                 default: 26
@@ -2752,6 +3374,12 @@ spec:
               postgresql:
                 description: Configuration of the PostgreSQL server
                 properties:
+                  enableAlterSystem:
+                    description: If this parameter is true, the user will be able
+                      to invoke `ALTER SYSTEM` on this CloudNativePG Cluster. This
+                      should only be used for debugging and troubleshooting. Defaults
+                      to false.
+                    type: boolean
                   ldap:
                     description: Options to specify LDAP configuration
                     properties:
@@ -2829,6 +3457,12 @@ spec:
                   pg_hba:
                     description: PostgreSQL Host Based Authentication rules (lines
                       to be appended to the pg_hba.conf file)
+                    items:
+                      type: string
+                    type: array
+                  pg_ident:
+                    description: PostgreSQL User Name Maps rules (lines to be appended
+                      to the pg_ident.conf file)
                     items:
                       type: string
                     type: array
@@ -3138,8 +3772,8 @@ spec:
                     description: If replica mode is enabled, this cluster will be
                       a replica of an existing cluster. Replica cluster can be created
                       from a recovery object store or via streaming through pg_basebackup.
-                      Refer to the Replication page of the documentation for more
-                      information.
+                      Refer to the Replica clusters page of the documentation for
+                      more information.
                     type: boolean
                   source:
                     description: The name of the external cluster which is the replication
@@ -3147,25 +3781,30 @@ spec:
                     minLength: 1
                     type: string
                 required:
+                - enabled
                 - source
                 type: object
               replicationSlots:
+                default:
+                  highAvailability:
+                    enabled: true
                 description: Replication slots management configuration
                 properties:
                   highAvailability:
+                    default:
+                      enabled: true
                     description: Replication slots for high availability configuration
                     properties:
                       enabled:
-                        default: false
-                        description: If enabled, the operator will automatically manage
-                          replication slots on the primary instance and use them in
-                          streaming replication connections with all the standby instances
-                          that are part of the HA cluster. If disabled (default),
+                        default: true
+                        description: If enabled (default), the operator will automatically
+                          manage replication slots on the primary instance and use
+                          them in streaming replication connections with all the standby
+                          instances that are part of the HA cluster. If disabled,
                           the operator will not take advantage of replication slots
                           in streaming connections with the replicas. This feature
                           also controls replication slots in replica cluster, from
-                          the designated primary to its cascading replicas. This can
-                          only be set at creation time.
+                          the designated primary to its cascading replicas.
                         type: boolean
                       slotPrefix:
                         default: _cnpg_
@@ -3246,8 +3885,8 @@ spec:
                     description: localhostProfile indicates a profile defined in a
                       file on the node should be used. The profile must be preconfigured
                       on the node to work. Must be a descending path, relative to
-                      the kubelet's configured seccomp profile location. Must only
-                      be set if type is "Localhost".
+                      the kubelet's configured seccomp profile location. Must be set
+                      if type is "Localhost". Must NOT be set for any other type.
                     type: string
                   type:
                     description: "type indicates which kind of seccomp profile will
@@ -3287,16 +3926,26 @@ spec:
                 required:
                 - metadata
                 type: object
+              smartShutdownTimeout:
+                default: 180
+                description: 'The time in seconds that controls the window of time
+                  reserved for the smart shutdown of Postgres to complete. Make sure
+                  you reserve enough time for the operator to request a fast shutdown
+                  of Postgres (that is: `stopDelay` - `smartShutdownTimeout`).'
+                format: int32
+                type: integer
               startDelay:
-                default: 30
-                description: The time in seconds that is allowed for a PostgreSQL
-                  instance to successfully start up (default 30)
+                default: 3600
+                description: 'The time in seconds that is allowed for a PostgreSQL
+                  instance to successfully start up (default 3600). The startup probe
+                  failure threshold is derived from this value using the formula:
+                  ceiling(startDelay / 10).'
                 format: int32
                 type: integer
               stopDelay:
-                default: 30
+                default: 1800
                 description: The time in seconds that is allowed for a PostgreSQL
-                  instance to gracefully shutdown (default 30)
+                  instance to gracefully shutdown (default 1800)
                 format: int32
                 type: integer
               storage:
@@ -3521,10 +4170,9 @@ spec:
                       reapplied to the created PVCs. Size cannot be decreased.
                     type: string
                   storageClass:
-                    description: StorageClass to use for database data (`PGDATA`).
-                      Applied after evaluating the PVC template, if available. If
-                      not specified, generated PVCs will be satisfied by the default
-                      storage class
+                    description: StorageClass to use for PVCs. Applied after evaluating
+                      the PVC template, if available. If not specified, the generated
+                      PVCs will use the default storage class
                     type: string
                 type: object
               superuserSecret:
@@ -3538,13 +4186,279 @@ spec:
                 - name
                 type: object
               switchoverDelay:
-                default: 40000000
+                default: 3600
                 description: The time in seconds that is allowed for a primary PostgreSQL
                   instance to gracefully shutdown during a switchover. Default value
-                  is 40000000, greater than one year in seconds, big enough to simulate
-                  an infinite delay
+                  is 3600 seconds (1 hour).
                 format: int32
                 type: integer
+              tablespaces:
+                description: The tablespaces configuration
+                items:
+                  description: TablespaceConfiguration is the configuration of a tablespace,
+                    and includes the storage specification for the tablespace
+                  properties:
+                    name:
+                      description: The name of the tablespace
+                      type: string
+                    owner:
+                      description: Owner is the PostgreSQL user owning the tablespace
+                      properties:
+                        name:
+                          type: string
+                      type: object
+                    storage:
+                      description: The storage configuration for the tablespace
+                      properties:
+                        pvcTemplate:
+                          description: Template to be used to generate the Persistent
+                            Volume Claim
+                          properties:
+                            accessModes:
+                              description: 'accessModes contains the desired access
+                                modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              description: 'dataSource field can be used to specify
+                                either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                * An existing PVC (PersistentVolumeClaim) If the provisioner
+                                or an external controller can support the specified
+                                data source, it will create a new volume based on
+                                the contents of the specified data source. When the
+                                AnyVolumeDataSource feature gate is enabled, dataSource
+                                contents will be copied to dataSourceRef, and dataSourceRef
+                                contents will be copied to dataSource when dataSourceRef.namespace
+                                is not specified. If the namespace is specified, then
+                                dataSourceRef will not be copied to dataSource.'
+                              properties:
+                                apiGroup:
+                                  description: APIGroup is the group for the resource
+                                    being referenced. If APIGroup is not specified,
+                                    the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            dataSourceRef:
+                              description: 'dataSourceRef specifies the object from
+                                which to populate the volume with data, if a non-empty
+                                volume is desired. This may be any object from a non-empty
+                                API group (non core object) or a PersistentVolumeClaim
+                                object. When this field is specified, volume binding
+                                will only succeed if the type of the specified object
+                                matches some installed volume populator or dynamic
+                                provisioner. This field will replace the functionality
+                                of the dataSource field and as such if both fields
+                                are non-empty, they must have the same value. For
+                                backwards compatibility, when namespace isn''t specified
+                                in dataSourceRef, both fields (dataSource and dataSourceRef)
+                                will be set to the same value automatically if one
+                                of them is empty and the other is non-empty. When
+                                namespace is specified in dataSourceRef, dataSource
+                                isn''t set to the same value and must be empty. There
+                                are three important differences between dataSource
+                                and dataSourceRef: * While dataSource only allows
+                                two specific types of objects, dataSourceRef allows
+                                any non-core object, as well as PersistentVolumeClaim
+                                objects. * While dataSource ignores disallowed values
+                                (dropping them), dataSourceRef preserves all values,
+                                and generates an error if a disallowed value is specified.
+                                * While dataSource only allows local objects, dataSourceRef
+                                allows objects in any namespaces. (Beta) Using this
+                                field requires the AnyVolumeDataSource feature gate
+                                to be enabled. (Alpha) Using the namespace field of
+                                dataSourceRef requires the CrossNamespaceVolumeDataSource
+                                feature gate to be enabled.'
+                              properties:
+                                apiGroup:
+                                  description: APIGroup is the group for the resource
+                                    being referenced. If APIGroup is not specified,
+                                    the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                                namespace:
+                                  description: Namespace is the namespace of resource
+                                    being referenced Note that when a namespace is
+                                    specified, a gateway.networking.k8s.io/ReferenceGrant
+                                    object is required in the referent namespace to
+                                    allow that namespace's owner to accept the reference.
+                                    See the ReferenceGrant documentation for details.
+                                    (Alpha) This field requires the CrossNamespaceVolumeDataSource
+                                    feature gate to be enabled.
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            resources:
+                              description: 'resources represents the minimum resources
+                                the volume should have. If RecoverVolumeExpansionFailure
+                                feature is enabled users are allowed to specify resource
+                                requirements that are lower than previous value but
+                                must still be higher than capacity recorded in the
+                                status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                              properties:
+                                claims:
+                                  description: "Claims lists the names of resources,
+                                    defined in spec.resourceClaims, that are used
+                                    by this container. \n This is an alpha field and
+                                    requires enabling the DynamicResourceAllocation
+                                    feature gate. \n This field is immutable. It can
+                                    only be set for containers."
+                                  items:
+                                    description: ResourceClaim references one entry
+                                      in PodSpec.ResourceClaims.
+                                    properties:
+                                      name:
+                                        description: Name must match the name of one
+                                          entry in pod.spec.resourceClaims of the
+                                          Pod where this field is used. It makes that
+                                          resource available inside a container.
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. Requests cannot
+                                    exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                              type: object
+                            selector:
+                              description: selector is a label query over volumes
+                                to consider for binding.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            storageClassName:
+                              description: 'storageClassName is the name of the StorageClass
+                                required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                              type: string
+                            volumeMode:
+                              description: volumeMode defines what type of volume
+                                is required by the claim. Value of Filesystem is implied
+                                when not included in claim spec.
+                              type: string
+                            volumeName:
+                              description: volumeName is the binding reference to
+                                the PersistentVolume backing this claim.
+                              type: string
+                          type: object
+                        resizeInUseVolumes:
+                          default: true
+                          description: Resize existent PVCs, defaults to true
+                          type: boolean
+                        size:
+                          description: Size of the storage. Required if not already
+                            specified in the PVC template. Changes to this field are
+                            automatically reapplied to the created PVCs. Size cannot
+                            be decreased.
+                          type: string
+                        storageClass:
+                          description: StorageClass to use for PVCs. Applied after
+                            evaluating the PVC template, if available. If not specified,
+                            the generated PVCs will use the default storage class
+                          type: string
+                      type: object
+                    temporary:
+                      default: false
+                      description: When set to true, the tablespace will be added
+                        as a `temp_tablespaces` entry in PostgreSQL, and will be available
+                        to automatically house temp database objects, or other temporary
+                        files. Please refer to PostgreSQL documentation for more information
+                        on the `temp_tablespaces` GUC.
+                      type: boolean
+                  required:
+                  - name
+                  - storage
+                  type: object
+                type: array
               topologySpreadConstraints:
                 description: 'TopologySpreadConstraints specifies how to spread matching
                   pods among the given topology. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/'
@@ -3941,10 +4855,9 @@ spec:
                       reapplied to the created PVCs. Size cannot be decreased.
                     type: string
                   storageClass:
-                    description: StorageClass to use for database data (`PGDATA`).
-                      Applied after evaluating the PVC template, if available. If
-                      not specified, generated PVCs will be satisfied by the default
-                      storage class
+                    description: StorageClass to use for PVCs. Applied after evaluating
+                      the PVC template, if available. If not specified, the generated
+                      PVCs will use the default storage class
                     type: string
                 type: object
             required:
@@ -4101,8 +5014,8 @@ spec:
                 type: string
               currentPrimaryFailingSinceTimestamp:
                 description: The timestamp when the primary was detected to be unhealthy
-                  This field is reported when spec.failoverDelay is populated or during
-                  online upgrades
+                  This field is reported when `.spec.failoverDelay` is populated or
+                  during online upgrades
                 type: string
               currentPrimaryTimestamp:
                 description: The timestamp when the last actual promotion to primary
@@ -4116,8 +5029,15 @@ spec:
                 type: array
               firstRecoverabilityPoint:
                 description: The first recoverability point, stored as a date in RFC3339
-                  format
+                  format. This field is calculated from the content of FirstRecoverabilityPointByMethod
                 type: string
+              firstRecoverabilityPointByMethod:
+                additionalProperties:
+                  format: date-time
+                  type: string
+                description: The first recoverability point, stored as a date in RFC3339
+                  format, per backup method type
+                type: object
               healthyPVC:
                 description: List of all the PVCs not dangling nor initializing
                 items:
@@ -4171,8 +5091,16 @@ spec:
                 description: Stored as a date in RFC3339 format
                 type: string
               lastSuccessfulBackup:
-                description: Stored as a date in RFC3339 format
+                description: Last successful backup, stored as a date in RFC3339 format
+                  This field is calculated from the content of LastSuccessfulBackupByMethod
                 type: string
+              lastSuccessfulBackupByMethod:
+                additionalProperties:
+                  format: date-time
+                  type: string
+                description: Last successful backup, stored as a date in RFC3339 format,
+                  per backup method type
+                type: object
               latestGeneratedNode:
                 description: ID of the latest generated node (used to avoid node name
                   clashing)
@@ -4272,6 +5200,11 @@ spec:
                     description: The resource version of the PostgreSQL client-side
                       CA secret version
                     type: string
+                  externalClusterSecretVersion:
+                    additionalProperties:
+                      type: string
+                    description: The resource versions of the external cluster secrets
+                    type: object
                   managedRoleSecretVersion:
                     additionalProperties:
                       type: string
@@ -4300,6 +5233,30 @@ spec:
                     description: The resource version of the "postgres" user secret
                     type: string
                 type: object
+              tablespacesStatus:
+                description: TablespacesStatus reports the state of the declarative
+                  tablespaces in the cluster
+                items:
+                  description: TablespaceState represents the state of a tablespace
+                    in a cluster
+                  properties:
+                    error:
+                      description: Error is the reconciliation error, if any
+                      type: string
+                    name:
+                      description: Name is the name of the tablespace
+                      type: string
+                    owner:
+                      description: Owner is the PostgreSQL user owning the tablespace
+                      type: string
+                    state:
+                      description: State is the latest reconciliation state
+                      type: string
+                  required:
+                  - name
+                  - state
+                  type: object
+                type: array
               targetPrimary:
                 description: Target primary instance, this is different from the previous
                   one during a switchover or a failover
@@ -4348,6 +5305,9 @@ spec:
                 description: Current write pod
                 type: string
             type: object
+        required:
+        - metadata
+        - spec
         type: object
     served: true
     storage: true
@@ -4361,7 +5321,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: poolers.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -4400,7 +5360,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: PoolerSpec defines the desired state of Pooler
+            description: 'Specification of the desired behavior of the Pooler. More
+              info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
             properties:
               cluster:
                 description: This is the cluster reference on which the Pooler will
@@ -4463,7 +5424,7 @@ spec:
                 type: object
               instances:
                 default: 1
-                description: The number of replicas we want
+                description: 'The number of replicas we want. Default: 1.'
                 format: int32
                 type: integer
               monitoring:
@@ -4474,6 +5435,156 @@ spec:
                     default: false
                     description: Enable or disable the `PodMonitor`
                     type: boolean
+                  podMonitorMetricRelabelings:
+                    description: The list of metric relabelings for the `PodMonitor`.
+                      Applied to samples before ingestion.
+                    items:
+                      description: "RelabelConfig allows dynamic rewriting of the
+                        label set for targets, alerts, scraped samples and remote
+                        write samples. \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
+                      properties:
+                        action:
+                          default: replace
+                          description: "Action to perform based on the regex matching.
+                            \n `Uppercase` and `Lowercase` actions require Prometheus
+                            >= v2.36.0. `DropEqual` and `KeepEqual` actions require
+                            Prometheus >= v2.41.0. \n Default: \"Replace\""
+                          enum:
+                          - replace
+                          - Replace
+                          - keep
+                          - Keep
+                          - drop
+                          - Drop
+                          - hashmod
+                          - HashMod
+                          - labelmap
+                          - LabelMap
+                          - labeldrop
+                          - LabelDrop
+                          - labelkeep
+                          - LabelKeep
+                          - lowercase
+                          - Lowercase
+                          - uppercase
+                          - Uppercase
+                          - keepequal
+                          - KeepEqual
+                          - dropequal
+                          - DropEqual
+                          type: string
+                        modulus:
+                          description: "Modulus to take of the hash of the source
+                            label values. \n Only applicable when the action is `HashMod`."
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched.
+                          type: string
+                        replacement:
+                          description: "Replacement value against which a Replace
+                            action is performed if the regular expression matches.
+                            \n Regex capture groups are available."
+                          type: string
+                        separator:
+                          description: Separator is the string between concatenated
+                            SourceLabels.
+                          type: string
+                        sourceLabels:
+                          description: The source labels select values from existing
+                            labels. Their content is concatenated using the configured
+                            Separator and matched against the configured regular expression.
+                          items:
+                            description: LabelName is a valid Prometheus label name
+                              which may only contain ASCII letters, numbers, as well
+                              as underscores.
+                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: "Label to which the resulting string is written
+                            in a replacement. \n It is mandatory for `Replace`, `HashMod`,
+                            `Lowercase`, `Uppercase`, `KeepEqual` and `DropEqual`
+                            actions. \n Regex capture groups are available."
+                          type: string
+                      type: object
+                    type: array
+                  podMonitorRelabelings:
+                    description: The list of relabelings for the `PodMonitor`. Applied
+                      to samples before scraping.
+                    items:
+                      description: "RelabelConfig allows dynamic rewriting of the
+                        label set for targets, alerts, scraped samples and remote
+                        write samples. \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
+                      properties:
+                        action:
+                          default: replace
+                          description: "Action to perform based on the regex matching.
+                            \n `Uppercase` and `Lowercase` actions require Prometheus
+                            >= v2.36.0. `DropEqual` and `KeepEqual` actions require
+                            Prometheus >= v2.41.0. \n Default: \"Replace\""
+                          enum:
+                          - replace
+                          - Replace
+                          - keep
+                          - Keep
+                          - drop
+                          - Drop
+                          - hashmod
+                          - HashMod
+                          - labelmap
+                          - LabelMap
+                          - labeldrop
+                          - LabelDrop
+                          - labelkeep
+                          - LabelKeep
+                          - lowercase
+                          - Lowercase
+                          - uppercase
+                          - Uppercase
+                          - keepequal
+                          - KeepEqual
+                          - dropequal
+                          - DropEqual
+                          type: string
+                        modulus:
+                          description: "Modulus to take of the hash of the source
+                            label values. \n Only applicable when the action is `HashMod`."
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched.
+                          type: string
+                        replacement:
+                          description: "Replacement value against which a Replace
+                            action is performed if the regular expression matches.
+                            \n Regex capture groups are available."
+                          type: string
+                        separator:
+                          description: Separator is the string between concatenated
+                            SourceLabels.
+                          type: string
+                        sourceLabels:
+                          description: The source labels select values from existing
+                            labels. Their content is concatenated using the configured
+                            Separator and matched against the configured regular expression.
+                          items:
+                            description: LabelName is a valid Prometheus label name
+                              which may only contain ASCII letters, numbers, as well
+                              as underscores.
+                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: "Label to which the resulting string is written
+                            in a replacement. \n It is mandatory for `Replace`, `HashMod`,
+                            `Lowercase`, `Uppercase`, `KeepEqual` and `DropEqual`
+                            actions. \n Regex capture groups are available."
+                          type: string
+                      type: object
+                    type: array
                 type: object
               pgbouncer:
                 description: The PgBouncer configuration
@@ -4521,13 +5632,11 @@ spec:
                     type: array
                   poolMode:
                     default: session
-                    description: The pool mode
+                    description: 'The pool mode. Default: `session`.'
                     enum:
                     - session
                     - transaction
                     type: string
-                required:
-                - poolMode
                 type: object
               template:
                 description: The template of the Pod to be created
@@ -6353,6 +7462,28 @@ spec:
                                     exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                   type: object
                               type: object
+                            restartPolicy:
+                              description: 'RestartPolicy defines the restart behavior
+                                of individual containers in a pod. This field may
+                                only be set for init containers, and the only allowed
+                                value is "Always". For non-init containers or when
+                                this field is not specified, the restart behavior
+                                is defined by the Pod''s restart policy and the container
+                                type. Setting the RestartPolicy as "Always" for the
+                                init container will have the following effect: this
+                                init container will be continually restarted on exit
+                                until all regular containers have terminated. Once
+                                all regular containers have completed, all init containers
+                                with restartPolicy "Always" will be shut down. This
+                                lifecycle differs from normal init containers and
+                                is often referred to as a "sidecar" container. Although
+                                this init container still starts in the init container
+                                sequence, it does not wait for the container to complete
+                                before proceeding to the next init container. Instead,
+                                the next init container starts immediately after this
+                                init container is started, or after any startupProbe
+                                has successfully completed.'
+                              type: string
                             securityContext:
                               description: 'SecurityContext defines the security options
                                 the container should be run with. If set, the fields
@@ -6482,7 +7613,8 @@ spec:
                                         The profile must be preconfigured on the node
                                         to work. Must be a descending path, relative
                                         to the kubelet's configured seccomp profile
-                                        location. Must only be set if type is "Localhost".
+                                        location. Must be set if type is "Localhost".
+                                        Must NOT be set for any other type.
                                       type: string
                                     type:
                                       description: "type indicates which kind of seccomp
@@ -6518,14 +7650,10 @@ spec:
                                     hostProcess:
                                       description: HostProcess determines if a container
                                         should be run as a 'Host Process' container.
-                                        This field is alpha-level and will only be
-                                        honored by components that enable the WindowsHostProcessContainers
-                                        feature flag. Setting this field without the
-                                        feature flag will result in errors when validating
-                                        the Pod. All of a Pod's containers must have
-                                        the same effective HostProcess value (it is
-                                        not allowed to have a mix of HostProcess containers
-                                        and non-HostProcess containers).  In addition,
+                                        All of a Pod's containers must have the same
+                                        effective HostProcess value (it is not allowed
+                                        to have a mix of HostProcess containers and
+                                        non-HostProcess containers). In addition,
                                         if HostProcess is true then HostNetwork must
                                         also be set to true.
                                       type: boolean
@@ -7759,6 +8887,12 @@ spec:
                                     exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                   type: object
                               type: object
+                            restartPolicy:
+                              description: Restart policy for the container to manage
+                                the restart behavior of each container within a pod.
+                                This may only be set for init containers. You cannot
+                                set this field on ephemeral containers.
+                              type: string
                             securityContext:
                               description: 'Optional: SecurityContext defines the
                                 security options the ephemeral container should be
@@ -7888,7 +9022,8 @@ spec:
                                         The profile must be preconfigured on the node
                                         to work. Must be a descending path, relative
                                         to the kubelet's configured seccomp profile
-                                        location. Must only be set if type is "Localhost".
+                                        location. Must be set if type is "Localhost".
+                                        Must NOT be set for any other type.
                                       type: string
                                     type:
                                       description: "type indicates which kind of seccomp
@@ -7924,14 +9059,10 @@ spec:
                                     hostProcess:
                                       description: HostProcess determines if a container
                                         should be run as a 'Host Process' container.
-                                        This field is alpha-level and will only be
-                                        honored by components that enable the WindowsHostProcessContainers
-                                        feature flag. Setting this field without the
-                                        feature flag will result in errors when validating
-                                        the Pod. All of a Pod's containers must have
-                                        the same effective HostProcess value (it is
-                                        not allowed to have a mix of HostProcess containers
-                                        and non-HostProcess containers).  In addition,
+                                        All of a Pod's containers must have the same
+                                        effective HostProcess value (it is not allowed
+                                        to have a mix of HostProcess containers and
+                                        non-HostProcess containers). In addition,
                                         if HostProcess is true then HostNetwork must
                                         also be set to true.
                                       type: boolean
@@ -9198,6 +10329,28 @@ spec:
                                     exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                   type: object
                               type: object
+                            restartPolicy:
+                              description: 'RestartPolicy defines the restart behavior
+                                of individual containers in a pod. This field may
+                                only be set for init containers, and the only allowed
+                                value is "Always". For non-init containers or when
+                                this field is not specified, the restart behavior
+                                is defined by the Pod''s restart policy and the container
+                                type. Setting the RestartPolicy as "Always" for the
+                                init container will have the following effect: this
+                                init container will be continually restarted on exit
+                                until all regular containers have terminated. Once
+                                all regular containers have completed, all init containers
+                                with restartPolicy "Always" will be shut down. This
+                                lifecycle differs from normal init containers and
+                                is often referred to as a "sidecar" container. Although
+                                this init container still starts in the init container
+                                sequence, it does not wait for the container to complete
+                                before proceeding to the next init container. Instead,
+                                the next init container starts immediately after this
+                                init container is started, or after any startupProbe
+                                has successfully completed.'
+                              type: string
                             securityContext:
                               description: 'SecurityContext defines the security options
                                 the container should be run with. If set, the fields
@@ -9327,7 +10480,8 @@ spec:
                                         The profile must be preconfigured on the node
                                         to work. Must be a descending path, relative
                                         to the kubelet's configured seccomp profile
-                                        location. Must only be set if type is "Localhost".
+                                        location. Must be set if type is "Localhost".
+                                        Must NOT be set for any other type.
                                       type: string
                                     type:
                                       description: "type indicates which kind of seccomp
@@ -9363,14 +10517,10 @@ spec:
                                     hostProcess:
                                       description: HostProcess determines if a container
                                         should be run as a 'Host Process' container.
-                                        This field is alpha-level and will only be
-                                        honored by components that enable the WindowsHostProcessContainers
-                                        feature flag. Setting this field without the
-                                        feature flag will result in errors when validating
-                                        the Pod. All of a Pod's containers must have
-                                        the same effective HostProcess value (it is
-                                        not allowed to have a mix of HostProcess containers
-                                        and non-HostProcess containers).  In addition,
+                                        All of a Pod's containers must have the same
+                                        effective HostProcess value (it is not allowed
+                                        to have a mix of HostProcess containers and
+                                        non-HostProcess containers). In addition,
                                         if HostProcess is true then HostNetwork must
                                         also be set to true.
                                       type: boolean
@@ -9806,19 +10956,14 @@ spec:
                                     namespace as this pod. \n The template will be
                                     used to create a new ResourceClaim, which will
                                     be bound to this pod. When this pod is deleted,
-                                    the ResourceClaim will also be deleted. The name
-                                    of the ResourceClaim will be <pod name>-<resource
-                                    name>, where <resource name> is the PodResourceClaim.Name.
-                                    Pod validation will reject the pod if the concatenated
-                                    name is not valid for a ResourceClaim (e.g. too
-                                    long). \n An existing ResourceClaim with that
-                                    name that is not owned by the pod will not be
-                                    used for the pod to avoid using an unrelated resource
-                                    by mistake. Scheduling and pod startup are then
-                                    blocked until the unrelated ResourceClaim is removed.
-                                    \n This field is immutable and no changes will
-                                    be made to the corresponding ResourceClaim by
-                                    the control plane after creating the ResourceClaim."
+                                    the ResourceClaim will also be deleted. The pod
+                                    name and resource name, along with a generated
+                                    component, will be used to form a unique name
+                                    for the ResourceClaim, which will be recorded
+                                    in pod.status.resourceClaimStatuses. \n This field
+                                    is immutable and no changes will be made to the
+                                    corresponding ResourceClaim by the control plane
+                                    after creating the ResourceClaim."
                                   type: string
                               type: object
                           required:
@@ -9965,8 +11110,9 @@ spec:
                                   defined in a file on the node should be used. The
                                   profile must be preconfigured on the node to work.
                                   Must be a descending path, relative to the kubelet's
-                                  configured seccomp profile location. Must only be
-                                  set if type is "Localhost".
+                                  configured seccomp profile location. Must be set
+                                  if type is "Localhost". Must NOT be set for any
+                                  other type.
                                 type: string
                               type:
                                 description: "type indicates which kind of seccomp
@@ -10034,15 +11180,11 @@ spec:
                                 type: string
                               hostProcess:
                                 description: HostProcess determines if a container
-                                  should be run as a 'Host Process' container. This
-                                  field is alpha-level and will only be honored by
-                                  components that enable the WindowsHostProcessContainers
-                                  feature flag. Setting this field without the feature
-                                  flag will result in errors when validating the Pod.
-                                  All of a Pod's containers must have the same effective
+                                  should be run as a 'Host Process' container. All
+                                  of a Pod's containers must have the same effective
                                   HostProcess value (it is not allowed to have a mix
-                                  of HostProcess containers and non-HostProcess containers).  In
-                                  addition, if HostProcess is true then HostNetwork
+                                  of HostProcess containers and non-HostProcess containers).
+                                  In addition, if HostProcess is true then HostNetwork
                                   must also be set to true.
                                 type: boolean
                               runAsUserName:
@@ -12042,19 +13184,18 @@ spec:
                 type: object
               type:
                 default: rw
-                description: Which instances we must forward traffic to?
+                description: 'Type of service to forward traffic to. Default: `rw`.'
                 enum:
                 - rw
                 - ro
                 type: string
             required:
             - cluster
-            - instances
             - pgbouncer
-            - type
             type: object
           status:
-            description: PoolerStatus defines the observed state of Pooler
+            description: 'Most recently observed status of the Pooler. This data may
+              not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
             properties:
               instances:
                 description: The number of pods trying to be scheduled
@@ -12109,6 +13250,9 @@ spec:
                     type: object
                 type: object
             type: object
+        required:
+        - metadata
+        - spec
         type: object
     served: true
     storage: true
@@ -12122,7 +13266,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: scheduledbackups.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -12189,6 +13333,46 @@ spec:
                 description: If the first backup has to be immediately start after
                   creation or not
                 type: boolean
+              method:
+                default: barmanObjectStore
+                description: 'The backup method to be used, possible options are `barmanObjectStore`
+                  and `volumeSnapshot`. Defaults to: `barmanObjectStore`.'
+                enum:
+                - barmanObjectStore
+                - volumeSnapshot
+                type: string
+              online:
+                description: Whether the default type of backup with volume snapshots
+                  is online/hot (`true`, default) or offline/cold (`false`) Overrides
+                  the default setting specified in the cluster field '.spec.backup.volumeSnapshot.online'
+                type: boolean
+              onlineConfiguration:
+                description: Configuration parameters to control the online/hot backup
+                  with volume snapshots Overrides the default settings specified in
+                  the cluster '.backup.volumeSnapshot.onlineConfiguration' stanza
+                properties:
+                  immediateCheckpoint:
+                    description: Control whether the I/O workload for the backup initial
+                      checkpoint will be limited, according to the `checkpoint_completion_target`
+                      setting on the PostgreSQL server. If set to true, an immediate
+                      checkpoint will be used, meaning PostgreSQL will complete the
+                      checkpoint as soon as possible. `false` by default.
+                    type: boolean
+                  waitForArchive:
+                    default: true
+                    description: If false, the function will return immediately after
+                      the backup is completed, without waiting for WAL to be archived.
+                      This behavior is only useful with backup software that independently
+                      monitors WAL archiving. Otherwise, WAL required to make the
+                      backup consistent might be missing and make the backup useless.
+                      By default, or when this parameter is true, pg_backup_stop will
+                      wait for WAL to be archived when archiving is enabled. On a
+                      standby, this means that it will wait only when archive_mode
+                      = always. If write activity on the primary is low, it may be
+                      useful to run pg_switch_wal on the primary in order to trigger
+                      an immediate segment switch.
+                    type: boolean
+                type: object
               schedule:
                 description: The schedule does not follow the same format used in
                   Kubernetes CronJobs as it includes an additional seconds specifier,
@@ -12208,6 +13392,7 @@ spec:
                 - prefer-standby
                 type: string
             required:
+            - cluster
             - schedule
             type: object
           status:
@@ -12229,6 +13414,9 @@ spec:
                 format: date-time
                 type: string
             type: object
+        required:
+        - metadata
+        - spec
         type: object
     served: true
     storage: true
@@ -12567,6 +13755,16 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -12684,14 +13882,16 @@ data:
             description: "Time at which postgres started (based on epoch)"
 
     pg_replication:
-      query: "SELECT CASE WHEN NOT pg_catalog.pg_is_in_recovery()
+      query: "SELECT CASE WHEN (
+                NOT pg_catalog.pg_is_in_recovery()
+                OR pg_catalog.pg_last_wal_receive_lsn() = pg_catalog.pg_last_wal_replay_lsn())
               THEN 0
               ELSE GREATEST (0,
                 EXTRACT(EPOCH FROM (now() - pg_catalog.pg_last_xact_replay_timestamp())))
               END AS lag,
               pg_catalog.pg_is_in_recovery() AS in_recovery,
               EXISTS (TABLE pg_stat_wal_receiver) AS is_wal_receiver_up,
-              (SELECT count(*) FROM pg_stat_replication) AS streaming_replicas"
+              (SELECT count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas"
       metrics:
         - lag:
             usage: "GAUGE"
@@ -12712,7 +13912,10 @@ data:
           slot_type,
           database,
           active,
-          pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), restart_lsn)
+          (CASE pg_catalog.pg_is_in_recovery()
+            WHEN TRUE THEN pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_last_wal_receive_lsn(), restart_lsn)
+            ELSE pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), restart_lsn)
+          END) as pg_wal_lsn_diff
         FROM pg_catalog.pg_replication_slots
         WHERE NOT temporary
       metrics:
@@ -12893,6 +14096,7 @@ data:
        SELECT usename
          , COALESCE(application_name, '') AS application_name
          , COALESCE(client_addr::text, '') AS client_addr
+         , COALESCE(client_port::text, '') AS client_port
          , EXTRACT(EPOCH FROM backend_start) AS backend_start
          , COALESCE(pg_catalog.age(backend_xmin), 0) AS backend_xmin_age
          , pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), sent_lsn) AS sent_diff_bytes
@@ -12913,6 +14117,9 @@ data:
         - client_addr:
             usage: "LABEL"
             description: "Client IP address"
+        - client_port:
+            usage: "LABEL"
+            description: "Client TCP port"
         - backend_start:
             usage: "COUNTER"
             description: "Time when this process was started"
@@ -13002,14 +14209,14 @@ spec:
         - /manager
         env:
         - name: OPERATOR_IMAGE_NAME
-          value: ghcr.io/cloudnative-pg/cloudnative-pg:1.20.2
+          value: ghcr.io/cloudnative-pg/cloudnative-pg:1.22.1
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
         - name: MONITORING_QUERIES_CONFIGMAP
           value: cnpg-default-monitoring
-        image: ghcr.io/cloudnative-pg/cloudnative-pg:1.20.2
+        image: ghcr.io/cloudnative-pg/cloudnative-pg:1.22.1
         livenessProbe:
           httpGet:
             path: /readyz
@@ -13043,6 +14250,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsGroup: 10001
           runAsUser: 10001
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /controller
           name: scratch-data
@@ -13076,7 +14285,7 @@ webhooks:
       namespace: cnpg-system
       path: /mutate-postgresql-cnpg-io-v1-backup
   failurePolicy: Fail
-  name: mbackup.kb.io
+  name: mbackup.cnpg.io
   rules:
   - apiGroups:
     - postgresql.cnpg.io
@@ -13096,7 +14305,7 @@ webhooks:
       namespace: cnpg-system
       path: /mutate-postgresql-cnpg-io-v1-cluster
   failurePolicy: Fail
-  name: mcluster.kb.io
+  name: mcluster.cnpg.io
   rules:
   - apiGroups:
     - postgresql.cnpg.io
@@ -13116,7 +14325,7 @@ webhooks:
       namespace: cnpg-system
       path: /mutate-postgresql-cnpg-io-v1-scheduledbackup
   failurePolicy: Fail
-  name: mscheduledbackup.kb.io
+  name: mscheduledbackup.cnpg.io
   rules:
   - apiGroups:
     - postgresql.cnpg.io
@@ -13142,7 +14351,7 @@ webhooks:
       namespace: cnpg-system
       path: /validate-postgresql-cnpg-io-v1-backup
   failurePolicy: Fail
-  name: vbackup.kb.io
+  name: vbackup.cnpg.io
   rules:
   - apiGroups:
     - postgresql.cnpg.io
@@ -13162,7 +14371,7 @@ webhooks:
       namespace: cnpg-system
       path: /validate-postgresql-cnpg-io-v1-cluster
   failurePolicy: Fail
-  name: vcluster.kb.io
+  name: vcluster.cnpg.io
   rules:
   - apiGroups:
     - postgresql.cnpg.io
@@ -13182,7 +14391,7 @@ webhooks:
       namespace: cnpg-system
       path: /validate-postgresql-cnpg-io-v1-pooler
   failurePolicy: Fail
-  name: vpooler.kb.io
+  name: vpooler.cnpg.io
   rules:
   - apiGroups:
     - postgresql.cnpg.io
@@ -13202,7 +14411,7 @@ webhooks:
       namespace: cnpg-system
       path: /validate-postgresql-cnpg-io-v1-scheduledbackup
   failurePolicy: Fail
-  name: vscheduledbackup.kb.io
+  name: vscheduledbackup.cnpg.io
   rules:
   - apiGroups:
     - postgresql.cnpg.io

--- a/k8s/server/base/django/deployment.yaml
+++ b/k8s/server/base/django/deployment.yaml
@@ -7,35 +7,32 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/rewriteAppHTTPProbers: "false"
+        proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
     spec:
       containers:
+        # istio-proxies are injected by anthos, see `istio.io/rev: asm-managed` in ../namespace.yaml
+        # these are overrides for the default configuration of those injected proxy sidecars
       - name: istio-proxy
         image: auto
+        resources:
+          requests:
+            # Experiment: using the minimum pod resources https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#compute-class-min-max
+            cpu: 50m # + `server` container = 250m
+            memory: 112Mi # + `server` container = 512MiB
       - name: server
         securityContext:
           runAsUser: 5678
         env:
-        - name: IS_K8S
-          value: "true"
         - name: SECRET_KEY
           valueFrom:
             secretKeyRef:
               name: django-secret-key
               key: secret-key
-        - name: ALLOWED_HOSTS
-          value: "hopic-sdpac.phac-aspc.alpha.canada.ca,34.149.100.163,localhost,34.152.0.41,41.0.152.34.bc.googleusercontent.com"
         - name: SLACK_WEBHOOK_URL
           valueFrom:
             secretKeyRef:
               name: slack-webhook-url
               key: slack-url
-        - name: DB_NAME
-          value: "cpho-phase2_db"
-        - name: DB_HOST
-          value: "cpho-postgres14-cluster-rw"
-        - name: DB_PORT
-          value: "5432"
         - name: DB_USER
           valueFrom:
             secretKeyRef:
@@ -46,8 +43,6 @@ spec:
             secretKeyRef:
               name: cpho-postgres14-cluster-app
               key: password
-        - name: PHAC_ASPC_OAUTH_PROVIDER
-          value: "microsoft"
         - name: PHAC_ASPC_OAUTH_APP_CLIENT_ID
           valueFrom:
             secretKeyRef:
@@ -63,8 +58,6 @@ spec:
             secretKeyRef:
               name: phac-aspc-oauth-config
               key: microsoft-tenant
-        - name: ENABLE_LEGACY_LOG_IN # TODO temporary for dev purposes, not to be used in final prod
-          value: "true"
         readinessProbe:
           httpGet:
             path: /healthcheck

--- a/k8s/server/base/postgres/pg-cluster.yaml
+++ b/k8s/server/base/postgres/pg-cluster.yaml
@@ -3,7 +3,9 @@ kind: Cluster
 metadata:
   name: cpho-postgres14-cluster
 spec:
-  imageName: ghcr.io/cloudnative-pg/postgresql:14.9
+  # See for info regarding images: https://cloudnative-pg.io/documentation/1.22/#container-images
+  # Images are found here: https://github.com/cloudnative-pg/postgres-containers/pkgs/container/postgresql
+  imageName: ghcr.io/cloudnative-pg/postgresql:14.10
   primaryUpdateStrategy: unsupervised
 
 # PostGres Best Practices for the Logging 

--- a/k8s/server/overlays/ephemeral/django/configmap.yaml
+++ b/k8s/server/overlays/ephemeral/django/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: server
+data:
+  IS_K8S: "true"
+  ALLOWED_HOSTS: "${BRANCH_NAME}.dev.hopic-sdpac.phac-aspc.alpha.canada.ca,hopic-sdpac.phac-aspc.alpha.canada.ca,34.149.100.163,localhost,34.152.0.41,41.0.152.34.bc.googleusercontent.com"
+  DB_NAME: "cpho-phase2_db"
+  DB_HOST: "cpho-postgres14-cluster-rw"
+  DB_PORT: "5432"
+  PHAC_ASPC_OAUTH_PROVIDER: "microsoft"
+  ENABLE_LEGACY_LOG_IN: "true" # TODO temporary for dev purposes, not to be used in final prod

--- a/k8s/server/overlays/ephemeral/django/deployment.yaml
+++ b/k8s/server/overlays/ephemeral/django/deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: northamerica-northeast1-docker.pkg.dev/pht-01hp04dtnkf/hopic-k8s-images/cpho-phase2:main-65c9e6b5-1707346051
+        image: northamerica-northeast1-docker.pkg.dev/pht-01hp04dtnkf/hopic-k8s-images/cpho-phase2:main-65c9e6b5-1707346051 # {"$imagepolicy": "flux-system:server"}
         resources:
           # Autopilot only considers requests (see https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#resource-limits)
           requests:

--- a/k8s/server/overlays/ephemeral/django/deployment.yaml
+++ b/k8s/server/overlays/ephemeral/django/deployment.yaml
@@ -6,14 +6,6 @@ spec:
   template:
     spec:
       containers:
-      - name: istio-proxy
-        # istio-proxies are injected by anthos, see `istio.io/rev: asm-managed` in ../namespace.yaml
-        # these are overrides for the default configuration of those injected proxy sidecars
-        resources:
-          requests:
-            # Experiment: using the minimum pod resources https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#compute-class-min-max
-            cpu: 50m # + `server` container = 250m
-            memory: 112Mi # + `server` container = 512MiB
       - name: server
         image: northamerica-northeast1-docker.pkg.dev/phx-01h4rr1468rj3v5k60b1vserd3/cpho-phase2-artifact-registry-for-cloud-run/cpho-phase2:server-kustomize-refactor-1a2287b6-1704295947 # {"$imagepolicy": "flux-system:server"}
         resources:
@@ -22,6 +14,6 @@ spec:
             # Experiment: using the minimum pod resources https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#compute-class-min-max
             cpu: 200m # + `isito-proxy` container = 250m
             memory: 500Mi # + `isito-proxy` container = 512MiB
-        env:
-        - name: ALLOWED_HOSTS
-          value: "${BRANCH_NAME}.dev.hopic-sdpac.phac-aspc.alpha.canada.ca,hopic-sdpac.phac-aspc.alpha.canada.ca,34.149.100.163,localhost,34.152.0.41,41.0.152.34.bc.googleusercontent.com"
+        envFrom:
+          - configMapRef:
+              name: server

--- a/k8s/server/overlays/ephemeral/django/deployment.yaml
+++ b/k8s/server/overlays/ephemeral/django/deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: northamerica-northeast1-docker.pkg.dev/phx-01h4rr1468rj3v5k60b1vserd3/cpho-phase2-artifact-registry-for-cloud-run/cpho-phase2:server-kustomize-refactor-1a2287b6-1704295947 # {"$imagepolicy": "flux-system:server"}
+        image: northamerica-northeast1-docker.pkg.dev/pht-01hp04dtnkf/hopic-k8s-images/cpho-phase2:main-65c9e6b5-1707346051
         resources:
           # Autopilot only considers requests (see https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#resource-limits)
           requests:

--- a/k8s/server/overlays/ephemeral/django/kustomization.yaml
+++ b/k8s/server/overlays/ephemeral/django/kustomization.yaml
@@ -16,5 +16,5 @@ namespace: ${BRANCH_NAME}
 # use a labelTransformer directive if you need to propagate a label only to the label field
 # see https://github.com/kubernetes-sigs/kustomize/blob/master/examples/transformerconfigs/README.md#labels-transformer
 commonLabels:
-  app: ephemeral
+  app: server
   branch: ${BRANCH_NAME}

--- a/k8s/server/overlays/ephemeral/django/kustomization.yaml
+++ b/k8s/server/overlays/ephemeral/django/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base/django/
+  - configmap.yaml
   - secrets.enc.yaml
   - virtual-service.yaml
 

--- a/k8s/server/overlays/ephemeral/django/secrets.enc.yaml
+++ b/k8s/server/overlays/ephemeral/django/secrets.enc.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-    secret-key: ENC[AES256_GCM,data:+3TMLnB3aGzyUPKqkjFY2W+MEErKppfBdMpn4LZ7cFKMfPpYmWQO8YLb4iaw3oXDpQMNVrM6zfx7EojCJkL3+RYL+LJrl7Ya,iv:AEEjGHRdwd1ASlwy+12yEkec3mSSkM9wMTJDqoAxbhg=,tag:QEzr7j6wRCa0aZyc0JJDpg==,type:str]
+    secret-key: ENC[AES256_GCM,data:Qn0uuQbwPdCWHmilTSLiKCWRPjyOmU9PH0VjOj9ftoStA87Hfwd5DWCPyqPX2x+PtIx92065e9mQqXVZnhELtir1p5/h2tYe,iv:2EpHDfRDau9SSbIpL42RJjX9+fG3oW/f3yolhnVWveo=,tag:2oYtxpemYtU0uN82x5IBkw==,type:str]
 kind: Secret
 metadata:
     name: django-secret-key
@@ -8,23 +8,23 @@ type: Opaque
 sops:
     kms: []
     gcp_kms:
-        - resource_id: projects/phx-01h4rr1468rj3v5k60b1vserd3/locations/northamerica-northeast1/keyRings/sops/cryptoKeys/sops-key
-          created_at: "2023-12-12T18:45:36Z"
-          enc: CiQABjWkUI/cDqGciCkvX2TljiXkDNnm7I5mM1kqs4Px2Qc0ESUSSQB/rzHLa302yTHjS0tBM/95N9PDTeG4zhyYdUQ/GJYx4v2hZmrloAmPRD5Ioz4GbI2Zg1UgWvR9y8DaUWxX/ptdknTLVrfMDZU=
+        - resource_id: projects/pht-01hp04dtnkf/locations/northamerica-northeast1/keyRings/sops/cryptoKeys/sops-flux-key
+          created_at: "2024-02-08T13:34:22Z"
+          enc: CiQA5+PIYg7eb8Zc2B5t5IKQ/xndpMuMJ8fl2h88VDDQVNJeYaISSQD25I1P6CNvi/WSFMZlS0AumN1MyFaSxiurlTF3RwVGULrg8MHwW+2lOnYXWIlSm2bGf0OE9dRNrVyRen/CkIxJ3eeY+tvht1g=
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-12-19T21:03:59Z"
-    mac: ENC[AES256_GCM,data:BRJcQP5Sh3qu79HGeEHcjGpl8EHr5n7XUTLKL97wVLNP3spYIvO+ZMwHDIQoRtCGJbEXQ7Fv1kQ7QZtRmDZ0QnqQjimpMI+DbxgCZ2WIN4J0WsMO5WprcxDcxWlv4Lp2/diz70mWM9LjCAfwk7jozFY3RToul39p8YrJf389Bwg=,iv:cW80U87J+keQY403gam/39BylEV7BO0wzqoSa+ItPBs=,tag:tGCFcFdpX5+yuSbqjyddRA==,type:str]
+    lastmodified: "2024-02-08T13:34:23Z"
+    mac: ENC[AES256_GCM,data:ADKBfmpmTnQZK1bLs0RjWCQ0AOGUWVaS/Viiwu01qpTz0gBq5dTr+fqn3cSIZEG/8qmiyIulhwFvcPz8JPGU97lALhlrZXOJZ22Akn5GOihfPQIlP6QcoGyNCHeS7rV3B+IKwQhyCnh7+uHqk6IP6GXJRcFKpMiC2wuwKLbmrzs=,iv:QdeuFBXGxPT2Eb0s1IMFGKn26mlEZkDhY59e6WH+5rQ=,tag:sAQMfriCHvw/GIf1Qb7wuQ==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.8.1
 ---
 apiVersion: v1
 data:
-    client-id: ENC[AES256_GCM,data:64aUQ2UwOW8xq2ajiWbtyWi8h2egdqsVdaHIDWCrme+R/RXZHDwP2bZqlk5+hy/L,iv:cXVbvgvOoy4yZNdiqu4G6s5U1Lf6+9pyH8Qw83sd/ME=,tag:Sp4h135YCNDNA1qQXEYJJg==,type:str]
-    client-secret: ENC[AES256_GCM,data:+S5FY0240MmdzZBcZ4uEHi5ybQuyZjssSz1xmGI5f9CvpqLYfzfvEcPfU0ell7D5UiG7lNUQlB4=,iv:BRc3/03VFKhyDUwgvjfg5SPsxoyQX/R3AbvOV+mQyZg=,tag:3mDqhxy7oGEnfYrVk5GG+Q==,type:str]
-    microsoft-tenant: ENC[AES256_GCM,data:URjlYy/5Xxo15WpbrrkLVb2qDgDiYHsZeFZgmJR7CO9O7oSIYzu+/YauBqfmoZo1,iv:1izXDyxhHwS0sBGsaFjEcWkTdFlRsnLN9QrU0EjvvJ4=,tag:DMMdilfBGAgPBBnB1U44Hw==,type:str]
+    client-id: ENC[AES256_GCM,data:kIdV4JC3YdSSf0h+sIF961h7JnJN7tL4L2OwpjDOkrwvG0ddUsD3vR0dPSyparJs,iv:Gz2vD1ARvhf1WJJLMyKApzu1oGHrvZdi7fjoY82i37U=,tag:YhlbqpukgQyjWWyYxQSQCg==,type:str]
+    client-secret: ENC[AES256_GCM,data:1NjHYJOiOmONhpGKOSG7rYHQXCChBvmEYsgf1JOry6nhyq2WAiBt23kOtL8bCQ5KhCH+AA3Z5g4=,iv:pkmE52L3N/d+o/jTll/aQf474ZoVjiQDAJr8dQZJ7fw=,tag:8gi35P4d53WDdodvMjpkQg==,type:str]
+    microsoft-tenant: ENC[AES256_GCM,data:CZdG0vZr0lzcYP1eBgFVILuICVPjyDIdCNzjZNzWGnoiw9GAw1lyoTsTQqZWz3mK,iv:Kt5ls5tAc6p6Zx2dpuwUotpJbZe1FmaaZN/Z5rUN450=,tag:SiULbYP4+UYALlGrjmGCuw==,type:str]
 kind: Secret
 metadata:
     name: phac-aspc-oauth-config
@@ -32,21 +32,21 @@ type: Opaque
 sops:
     kms: []
     gcp_kms:
-        - resource_id: projects/phx-01h4rr1468rj3v5k60b1vserd3/locations/northamerica-northeast1/keyRings/sops/cryptoKeys/sops-key
-          created_at: "2023-12-12T18:45:36Z"
-          enc: CiQABjWkUI/cDqGciCkvX2TljiXkDNnm7I5mM1kqs4Px2Qc0ESUSSQB/rzHLa302yTHjS0tBM/95N9PDTeG4zhyYdUQ/GJYx4v2hZmrloAmPRD5Ioz4GbI2Zg1UgWvR9y8DaUWxX/ptdknTLVrfMDZU=
+        - resource_id: projects/pht-01hp04dtnkf/locations/northamerica-northeast1/keyRings/sops/cryptoKeys/sops-flux-key
+          created_at: "2024-02-08T13:34:22Z"
+          enc: CiQA5+PIYg7eb8Zc2B5t5IKQ/xndpMuMJ8fl2h88VDDQVNJeYaISSQD25I1P6CNvi/WSFMZlS0AumN1MyFaSxiurlTF3RwVGULrg8MHwW+2lOnYXWIlSm2bGf0OE9dRNrVyRen/CkIxJ3eeY+tvht1g=
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-12-19T21:03:59Z"
-    mac: ENC[AES256_GCM,data:BRJcQP5Sh3qu79HGeEHcjGpl8EHr5n7XUTLKL97wVLNP3spYIvO+ZMwHDIQoRtCGJbEXQ7Fv1kQ7QZtRmDZ0QnqQjimpMI+DbxgCZ2WIN4J0WsMO5WprcxDcxWlv4Lp2/diz70mWM9LjCAfwk7jozFY3RToul39p8YrJf389Bwg=,iv:cW80U87J+keQY403gam/39BylEV7BO0wzqoSa+ItPBs=,tag:tGCFcFdpX5+yuSbqjyddRA==,type:str]
+    lastmodified: "2024-02-08T13:34:23Z"
+    mac: ENC[AES256_GCM,data:ADKBfmpmTnQZK1bLs0RjWCQ0AOGUWVaS/Viiwu01qpTz0gBq5dTr+fqn3cSIZEG/8qmiyIulhwFvcPz8JPGU97lALhlrZXOJZ22Akn5GOihfPQIlP6QcoGyNCHeS7rV3B+IKwQhyCnh7+uHqk6IP6GXJRcFKpMiC2wuwKLbmrzs=,iv:QdeuFBXGxPT2Eb0s1IMFGKn26mlEZkDhY59e6WH+5rQ=,tag:sAQMfriCHvw/GIf1Qb7wuQ==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.8.1
 ---
 apiVersion: v1
 data:
-    token: ENC[AES256_GCM,data:hhRznkudQpslHS4MC5vgudW3sh1FWGqWqalWFDtJErdodBygEKWxtZu/bNhC/Dk+JwAdfVmXdqQdd5/XubgVo5NjjCae0e7RedTV+g==,iv:EsoHxaT1gs+mk1XR/G7Ha5wIi1pbh01E/yTxhSgqaek=,tag:wUrpWDtPUrcdamePJo7WtQ==,type:str]
+    token: ENC[AES256_GCM,data:JokZaxT/iAEKUkqVe0V4SRHzF9V4qDPpymgEAX+V957tsr2phnEUIiu5ArGRt4iBjacamOeCO9KVgwueRnFnPou30hC3WmO/ixUMpg==,iv:AFOOV0Rht09iaaDezlJvX+WZBhWw7awhsp7Hetnvxsg=,tag:sN2jovpZbUcbY/EUHOtP+A==,type:str]
 kind: Secret
 metadata:
     name: slack-alerting-app-token
@@ -54,21 +54,21 @@ type: Opaque
 sops:
     kms: []
     gcp_kms:
-        - resource_id: projects/phx-01h4rr1468rj3v5k60b1vserd3/locations/northamerica-northeast1/keyRings/sops/cryptoKeys/sops-key
-          created_at: "2023-12-12T18:45:36Z"
-          enc: CiQABjWkUI/cDqGciCkvX2TljiXkDNnm7I5mM1kqs4Px2Qc0ESUSSQB/rzHLa302yTHjS0tBM/95N9PDTeG4zhyYdUQ/GJYx4v2hZmrloAmPRD5Ioz4GbI2Zg1UgWvR9y8DaUWxX/ptdknTLVrfMDZU=
+        - resource_id: projects/pht-01hp04dtnkf/locations/northamerica-northeast1/keyRings/sops/cryptoKeys/sops-flux-key
+          created_at: "2024-02-08T13:34:22Z"
+          enc: CiQA5+PIYg7eb8Zc2B5t5IKQ/xndpMuMJ8fl2h88VDDQVNJeYaISSQD25I1P6CNvi/WSFMZlS0AumN1MyFaSxiurlTF3RwVGULrg8MHwW+2lOnYXWIlSm2bGf0OE9dRNrVyRen/CkIxJ3eeY+tvht1g=
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-12-19T21:03:59Z"
-    mac: ENC[AES256_GCM,data:BRJcQP5Sh3qu79HGeEHcjGpl8EHr5n7XUTLKL97wVLNP3spYIvO+ZMwHDIQoRtCGJbEXQ7Fv1kQ7QZtRmDZ0QnqQjimpMI+DbxgCZ2WIN4J0WsMO5WprcxDcxWlv4Lp2/diz70mWM9LjCAfwk7jozFY3RToul39p8YrJf389Bwg=,iv:cW80U87J+keQY403gam/39BylEV7BO0wzqoSa+ItPBs=,tag:tGCFcFdpX5+yuSbqjyddRA==,type:str]
+    lastmodified: "2024-02-08T13:34:23Z"
+    mac: ENC[AES256_GCM,data:ADKBfmpmTnQZK1bLs0RjWCQ0AOGUWVaS/Viiwu01qpTz0gBq5dTr+fqn3cSIZEG/8qmiyIulhwFvcPz8JPGU97lALhlrZXOJZ22Akn5GOihfPQIlP6QcoGyNCHeS7rV3B+IKwQhyCnh7+uHqk6IP6GXJRcFKpMiC2wuwKLbmrzs=,iv:QdeuFBXGxPT2Eb0s1IMFGKn26mlEZkDhY59e6WH+5rQ=,tag:sAQMfriCHvw/GIf1Qb7wuQ==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.8.1
 ---
 apiVersion: v1
 data:
-    slack-url: ENC[AES256_GCM,data:Z2syNF1WYnSAkdjokPsYZK4nUS2vVynVneHWX8JFTw3UxXO8dZ9uqBwXuqZIocmmDrfWqokjqXL8TOFWwyRmpp15GoEXnUxSQD/gq2jamzMyo1cjdCDZ7YCmqK4RQXg/VwpmPmQCtsbkvWIR,iv:MHBR+/phj8I9CgXGmkRglC6vBXD8ZtM7GSB12lc9DP0=,tag:zeXn9c7ZiZ0gZa6TKOdehQ==,type:str]
+    slack-url: ENC[AES256_GCM,data:PomIPEBF0zfwF0MbHBcspI1Wd0ZudNteULlJYnrJ9A/QS/LSaXOXIcNT9Qxm1SLn1w0v7InLPszZAr+4RLaTqngSlj/rhzep0s+CF0TH9jLXRA+N/afbPNEcWWeF57HYv1SnGTRPeKyVrZ90,iv:t7ok7r6z99p3TjxRit3t4bMwNKkVl2QkpSOtoADYAEY=,tag:u2i7NYAliXktAnFHv5wF3Q==,type:str]
 kind: Secret
 metadata:
     name: slack-webhook-url
@@ -76,14 +76,14 @@ type: Opaque
 sops:
     kms: []
     gcp_kms:
-        - resource_id: projects/phx-01h4rr1468rj3v5k60b1vserd3/locations/northamerica-northeast1/keyRings/sops/cryptoKeys/sops-key
-          created_at: "2023-12-12T18:45:36Z"
-          enc: CiQABjWkUI/cDqGciCkvX2TljiXkDNnm7I5mM1kqs4Px2Qc0ESUSSQB/rzHLa302yTHjS0tBM/95N9PDTeG4zhyYdUQ/GJYx4v2hZmrloAmPRD5Ioz4GbI2Zg1UgWvR9y8DaUWxX/ptdknTLVrfMDZU=
+        - resource_id: projects/pht-01hp04dtnkf/locations/northamerica-northeast1/keyRings/sops/cryptoKeys/sops-flux-key
+          created_at: "2024-02-08T13:34:22Z"
+          enc: CiQA5+PIYg7eb8Zc2B5t5IKQ/xndpMuMJ8fl2h88VDDQVNJeYaISSQD25I1P6CNvi/WSFMZlS0AumN1MyFaSxiurlTF3RwVGULrg8MHwW+2lOnYXWIlSm2bGf0OE9dRNrVyRen/CkIxJ3eeY+tvht1g=
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-12-19T21:03:59Z"
-    mac: ENC[AES256_GCM,data:BRJcQP5Sh3qu79HGeEHcjGpl8EHr5n7XUTLKL97wVLNP3spYIvO+ZMwHDIQoRtCGJbEXQ7Fv1kQ7QZtRmDZ0QnqQjimpMI+DbxgCZ2WIN4J0WsMO5WprcxDcxWlv4Lp2/diz70mWM9LjCAfwk7jozFY3RToul39p8YrJf389Bwg=,iv:cW80U87J+keQY403gam/39BylEV7BO0wzqoSa+ItPBs=,tag:tGCFcFdpX5+yuSbqjyddRA==,type:str]
+    lastmodified: "2024-02-08T13:34:23Z"
+    mac: ENC[AES256_GCM,data:ADKBfmpmTnQZK1bLs0RjWCQ0AOGUWVaS/Viiwu01qpTz0gBq5dTr+fqn3cSIZEG/8qmiyIulhwFvcPz8JPGU97lALhlrZXOJZ22Akn5GOihfPQIlP6QcoGyNCHeS7rV3B+IKwQhyCnh7+uHqk6IP6GXJRcFKpMiC2wuwKLbmrzs=,iv:QdeuFBXGxPT2Eb0s1IMFGKn26mlEZkDhY59e6WH+5rQ=,tag:sAQMfriCHvw/GIf1Qb7wuQ==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.8.1

--- a/k8s/server/overlays/ephemeral/postgres/kustomization.yaml
+++ b/k8s/server/overlays/ephemeral/postgres/kustomization.yaml
@@ -14,5 +14,5 @@ namespace: ${BRANCH_NAME}
 # use a labelTransformer directive if you need to propagate a label only to the label field
 # see https://github.com/kubernetes-sigs/kustomize/blob/master/examples/transformerconfigs/README.md#labels-transformer
 commonLabels:
-  app: ephemeral
+  app: database
   branch: ${BRANCH_NAME}

--- a/k8s/server/overlays/prod/django/configmap.yaml
+++ b/k8s/server/overlays/prod/django/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: server
+data:
+  IS_K8S: "true"
+  ALLOWED_HOSTS: "hopic-sdpac.phac-aspc.alpha.canada.ca,34.149.100.163,localhost,34.152.0.41,41.0.152.34.bc.googleusercontent.com"
+  DB_NAME: "cpho-phase2_db"
+  DB_HOST: "cpho-postgres14-cluster-rw"
+  DB_PORT: "5432"
+  PHAC_ASPC_OAUTH_PROVIDER: "microsoft"
+  ENABLE_LEGACY_LOG_IN: "true" # TODO temporary for dev purposes, not to be used in final prod

--- a/k8s/server/overlays/prod/django/deployment.yaml
+++ b/k8s/server/overlays/prod/django/deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: northamerica-northeast1-docker.pkg.dev/pht-01hp04dtnkf/hopic-k8s-images/cpho-phase2:main-65c9e6b5-1707346051
+        image: northamerica-northeast1-docker.pkg.dev/pht-01hp04dtnkf/hopic-k8s-images/cpho-phase2:main-65c9e6b5-1707346051 # {"$imagepolicy": "flux-system:server"}
         resources:
           # Autopilot only considers requests (see https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#resource-limits)
           requests:

--- a/k8s/server/overlays/prod/django/deployment.yaml
+++ b/k8s/server/overlays/prod/django/deployment.yaml
@@ -6,19 +6,14 @@ spec:
   template:
     spec:
       containers:
-      - name: istio-proxy
-        # istio-proxies are injected by anthos, see `istio.io/rev: asm-managed` in ../namespace.yaml
-        # these are overrides for the default configuration of those injected proxy sidecars
-        resources:
-          requests:
-            # Experiment: using the minimum pod resources https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#compute-class-min-max
-            cpu: 50m # + `server` container = 250m
-            memory: 112Mi # + `server` container = 512MiB
       - name: server
-        image: northamerica-northeast1-docker.pkg.dev/phx-01h4rr1468rj3v5k60b1vserd3/cpho-phase2-artifact-registry-for-cloud-run/cpho-phase2:a11y-testing-b627c606-1702064694 # {"$imagepolicy": "flux-system:server"}
+        image: northamerica-northeast1-docker.pkg.dev/pht-01hp04dtnkf/hopic-k8s-images/cpho-phase2:main-65c9e6b5-1707346051
         resources:
           # Autopilot only considers requests (see https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#resource-limits)
           requests:
             # Experiment: using the minimum pod resources https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#compute-class-min-max
             cpu: 200m # + `isito-proxy` container = 250m
-            memory: 400Mi # + `isito-proxy` container = 512MiB
+            memory: 500Mi # + `isito-proxy` container = 612MiB
+        envFrom:
+          - configMapRef:
+              name: server

--- a/k8s/server/overlays/prod/django/kustomization.yaml
+++ b/k8s/server/overlays/prod/django/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base/django/
+  - configmap.yaml
   - secrets.enc.yaml
   - hpa.yaml
   - virtual-service.yaml
@@ -17,3 +18,4 @@ namespace: server
 # see https://github.com/kubernetes-sigs/kustomize/blob/master/examples/transformerconfigs/README.md#labels-transformer
 commonLabels:
   app: server
+  branch: main

--- a/k8s/server/overlays/prod/django/secrets.enc.yaml
+++ b/k8s/server/overlays/prod/django/secrets.enc.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-    secret-key: ENC[AES256_GCM,data:+3TMLnB3aGzyUPKqkjFY2W+MEErKppfBdMpn4LZ7cFKMfPpYmWQO8YLb4iaw3oXDpQMNVrM6zfx7EojCJkL3+RYL+LJrl7Ya,iv:AEEjGHRdwd1ASlwy+12yEkec3mSSkM9wMTJDqoAxbhg=,tag:QEzr7j6wRCa0aZyc0JJDpg==,type:str]
+    secret-key: ENC[AES256_GCM,data:b8L0VW+gOHddobbQs1/w4FLN8sY1VByNtnURWv59koeN2EpMHa5981UMU3A03wkMZimskyURZND/2r35tpcflGUQLUdfkVtn,iv:wt8UMusLe5PyFoDgSG28oNFq7l6cLIafE8/Wr09oyFk=,tag:sw+PI/jxJ+jktwvMkoB3jQ==,type:str]
 kind: Secret
 metadata:
     name: django-secret-key
@@ -8,23 +8,23 @@ type: Opaque
 sops:
     kms: []
     gcp_kms:
-        - resource_id: projects/phx-01h4rr1468rj3v5k60b1vserd3/locations/northamerica-northeast1/keyRings/sops/cryptoKeys/sops-key
-          created_at: "2023-12-12T18:45:36Z"
-          enc: CiQABjWkUI/cDqGciCkvX2TljiXkDNnm7I5mM1kqs4Px2Qc0ESUSSQB/rzHLa302yTHjS0tBM/95N9PDTeG4zhyYdUQ/GJYx4v2hZmrloAmPRD5Ioz4GbI2Zg1UgWvR9y8DaUWxX/ptdknTLVrfMDZU=
+        - resource_id: projects/pht-01hp04dtnkf/locations/northamerica-northeast1/keyRings/sops/cryptoKeys/sops-flux-key
+          created_at: "2024-02-08T13:33:46Z"
+          enc: CiQA5+PIYjf21HETzAuNArBQq3w0zqeuHki4yWgYbu8OPUVlQ80SSAD25I1PiU1mX6HIE1CiVEts57EArGPUwn08bzf30s2Z0/ynnn7wb1eNG7DZMJvFsgfQcaXn8GbiMQ+++Hq+Dnr77jK+d1PAAw==
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-12-19T21:03:59Z"
-    mac: ENC[AES256_GCM,data:BRJcQP5Sh3qu79HGeEHcjGpl8EHr5n7XUTLKL97wVLNP3spYIvO+ZMwHDIQoRtCGJbEXQ7Fv1kQ7QZtRmDZ0QnqQjimpMI+DbxgCZ2WIN4J0WsMO5WprcxDcxWlv4Lp2/diz70mWM9LjCAfwk7jozFY3RToul39p8YrJf389Bwg=,iv:cW80U87J+keQY403gam/39BylEV7BO0wzqoSa+ItPBs=,tag:tGCFcFdpX5+yuSbqjyddRA==,type:str]
+    lastmodified: "2024-02-08T13:33:46Z"
+    mac: ENC[AES256_GCM,data:tan9J7/dBC15Y0OL6zvKn/UcOdi9BuZmmcED6MV+AWzK3jXR2v7GgfPDATCw6cAcpZDOtzA9rNDZYgdFgQ6ljrZ2R8KVmTTRjoFA9Co8ZEBCg6+BMsNQe+T2UD7Pi3ISZ5+zHNvQFAdVdOe8IxZu2uIPIzsi6ajUyLTnxDuDGgk=,iv:DyRRJW66s84h68Ob8D/Giu7r584rdCPKC15CKKsGDOs=,tag:Cw+D9ATxwdWK4/GFiGQ1GA==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.8.1
 ---
 apiVersion: v1
 data:
-    client-id: ENC[AES256_GCM,data:64aUQ2UwOW8xq2ajiWbtyWi8h2egdqsVdaHIDWCrme+R/RXZHDwP2bZqlk5+hy/L,iv:cXVbvgvOoy4yZNdiqu4G6s5U1Lf6+9pyH8Qw83sd/ME=,tag:Sp4h135YCNDNA1qQXEYJJg==,type:str]
-    client-secret: ENC[AES256_GCM,data:+S5FY0240MmdzZBcZ4uEHi5ybQuyZjssSz1xmGI5f9CvpqLYfzfvEcPfU0ell7D5UiG7lNUQlB4=,iv:BRc3/03VFKhyDUwgvjfg5SPsxoyQX/R3AbvOV+mQyZg=,tag:3mDqhxy7oGEnfYrVk5GG+Q==,type:str]
-    microsoft-tenant: ENC[AES256_GCM,data:URjlYy/5Xxo15WpbrrkLVb2qDgDiYHsZeFZgmJR7CO9O7oSIYzu+/YauBqfmoZo1,iv:1izXDyxhHwS0sBGsaFjEcWkTdFlRsnLN9QrU0EjvvJ4=,tag:DMMdilfBGAgPBBnB1U44Hw==,type:str]
+    client-id: ENC[AES256_GCM,data:d9mQVi0OWhdK6UqNjLHrL5i9bjF2WC4uZPnXQSStamQcqM85QaJlNebAfPUIJZVf,iv:5tnkJcZeP+qTAZwfU12SRBVOQLYHd1Mb/9hJSUs701E=,tag:WwCxKMLVhnT1w7TG8/Absw==,type:str]
+    client-secret: ENC[AES256_GCM,data:yvFQafnJuehtKS0ZvIB8ajOkfs+QOdeiSWm7OHsDCvhc76Q3phvLYFuDolTFl3iD+BHLaRMsPPE=,iv:iHDWIH5G40hPoDk9T3aP7Cw5ATuMBEAKLu76YS6a4cc=,tag:neN/oz8JmshUnilkKqw7Og==,type:str]
+    microsoft-tenant: ENC[AES256_GCM,data:6UXw7e7VX3GwvQGylohqM9RJVIvGfkCwAKzuuwKxg08d9v+HTgsuV4GnnHThzCJ7,iv:aMfbyZ5ATiacXBB+ER1t+RrePYCjV1J5JLVf6v/SNpU=,tag:M23y5YC4ze3vah2VBVj2wg==,type:str]
 kind: Secret
 metadata:
     name: phac-aspc-oauth-config
@@ -32,21 +32,21 @@ type: Opaque
 sops:
     kms: []
     gcp_kms:
-        - resource_id: projects/phx-01h4rr1468rj3v5k60b1vserd3/locations/northamerica-northeast1/keyRings/sops/cryptoKeys/sops-key
-          created_at: "2023-12-12T18:45:36Z"
-          enc: CiQABjWkUI/cDqGciCkvX2TljiXkDNnm7I5mM1kqs4Px2Qc0ESUSSQB/rzHLa302yTHjS0tBM/95N9PDTeG4zhyYdUQ/GJYx4v2hZmrloAmPRD5Ioz4GbI2Zg1UgWvR9y8DaUWxX/ptdknTLVrfMDZU=
+        - resource_id: projects/pht-01hp04dtnkf/locations/northamerica-northeast1/keyRings/sops/cryptoKeys/sops-flux-key
+          created_at: "2024-02-08T13:33:46Z"
+          enc: CiQA5+PIYjf21HETzAuNArBQq3w0zqeuHki4yWgYbu8OPUVlQ80SSAD25I1PiU1mX6HIE1CiVEts57EArGPUwn08bzf30s2Z0/ynnn7wb1eNG7DZMJvFsgfQcaXn8GbiMQ+++Hq+Dnr77jK+d1PAAw==
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-12-19T21:03:59Z"
-    mac: ENC[AES256_GCM,data:BRJcQP5Sh3qu79HGeEHcjGpl8EHr5n7XUTLKL97wVLNP3spYIvO+ZMwHDIQoRtCGJbEXQ7Fv1kQ7QZtRmDZ0QnqQjimpMI+DbxgCZ2WIN4J0WsMO5WprcxDcxWlv4Lp2/diz70mWM9LjCAfwk7jozFY3RToul39p8YrJf389Bwg=,iv:cW80U87J+keQY403gam/39BylEV7BO0wzqoSa+ItPBs=,tag:tGCFcFdpX5+yuSbqjyddRA==,type:str]
+    lastmodified: "2024-02-08T13:33:46Z"
+    mac: ENC[AES256_GCM,data:tan9J7/dBC15Y0OL6zvKn/UcOdi9BuZmmcED6MV+AWzK3jXR2v7GgfPDATCw6cAcpZDOtzA9rNDZYgdFgQ6ljrZ2R8KVmTTRjoFA9Co8ZEBCg6+BMsNQe+T2UD7Pi3ISZ5+zHNvQFAdVdOe8IxZu2uIPIzsi6ajUyLTnxDuDGgk=,iv:DyRRJW66s84h68Ob8D/Giu7r584rdCPKC15CKKsGDOs=,tag:Cw+D9ATxwdWK4/GFiGQ1GA==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.8.1
 ---
 apiVersion: v1
 data:
-    token: ENC[AES256_GCM,data:hhRznkudQpslHS4MC5vgudW3sh1FWGqWqalWFDtJErdodBygEKWxtZu/bNhC/Dk+JwAdfVmXdqQdd5/XubgVo5NjjCae0e7RedTV+g==,iv:EsoHxaT1gs+mk1XR/G7Ha5wIi1pbh01E/yTxhSgqaek=,tag:wUrpWDtPUrcdamePJo7WtQ==,type:str]
+    token: ENC[AES256_GCM,data:f74U+CA9Cao1/5EABTuPt51CFM8iE1T/bVnhx4jtcGzNayFn/3p3wftr5AEzk3M8+QJf+TcP4U7MS8gUIgclJIGXZDFjpVL+3/a4Jw==,iv:UHwfSUQwqRP6jtT38TdT8yq3IrhAq++kixkwBWdYnIo=,tag:Ulb2Forb0UVIoEC+I3f4pg==,type:str]
 kind: Secret
 metadata:
     name: slack-alerting-app-token
@@ -54,21 +54,21 @@ type: Opaque
 sops:
     kms: []
     gcp_kms:
-        - resource_id: projects/phx-01h4rr1468rj3v5k60b1vserd3/locations/northamerica-northeast1/keyRings/sops/cryptoKeys/sops-key
-          created_at: "2023-12-12T18:45:36Z"
-          enc: CiQABjWkUI/cDqGciCkvX2TljiXkDNnm7I5mM1kqs4Px2Qc0ESUSSQB/rzHLa302yTHjS0tBM/95N9PDTeG4zhyYdUQ/GJYx4v2hZmrloAmPRD5Ioz4GbI2Zg1UgWvR9y8DaUWxX/ptdknTLVrfMDZU=
+        - resource_id: projects/pht-01hp04dtnkf/locations/northamerica-northeast1/keyRings/sops/cryptoKeys/sops-flux-key
+          created_at: "2024-02-08T13:33:46Z"
+          enc: CiQA5+PIYjf21HETzAuNArBQq3w0zqeuHki4yWgYbu8OPUVlQ80SSAD25I1PiU1mX6HIE1CiVEts57EArGPUwn08bzf30s2Z0/ynnn7wb1eNG7DZMJvFsgfQcaXn8GbiMQ+++Hq+Dnr77jK+d1PAAw==
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-12-19T21:03:59Z"
-    mac: ENC[AES256_GCM,data:BRJcQP5Sh3qu79HGeEHcjGpl8EHr5n7XUTLKL97wVLNP3spYIvO+ZMwHDIQoRtCGJbEXQ7Fv1kQ7QZtRmDZ0QnqQjimpMI+DbxgCZ2WIN4J0WsMO5WprcxDcxWlv4Lp2/diz70mWM9LjCAfwk7jozFY3RToul39p8YrJf389Bwg=,iv:cW80U87J+keQY403gam/39BylEV7BO0wzqoSa+ItPBs=,tag:tGCFcFdpX5+yuSbqjyddRA==,type:str]
+    lastmodified: "2024-02-08T13:33:46Z"
+    mac: ENC[AES256_GCM,data:tan9J7/dBC15Y0OL6zvKn/UcOdi9BuZmmcED6MV+AWzK3jXR2v7GgfPDATCw6cAcpZDOtzA9rNDZYgdFgQ6ljrZ2R8KVmTTRjoFA9Co8ZEBCg6+BMsNQe+T2UD7Pi3ISZ5+zHNvQFAdVdOe8IxZu2uIPIzsi6ajUyLTnxDuDGgk=,iv:DyRRJW66s84h68Ob8D/Giu7r584rdCPKC15CKKsGDOs=,tag:Cw+D9ATxwdWK4/GFiGQ1GA==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.8.1
 ---
 apiVersion: v1
 data:
-    slack-url: ENC[AES256_GCM,data:Z2syNF1WYnSAkdjokPsYZK4nUS2vVynVneHWX8JFTw3UxXO8dZ9uqBwXuqZIocmmDrfWqokjqXL8TOFWwyRmpp15GoEXnUxSQD/gq2jamzMyo1cjdCDZ7YCmqK4RQXg/VwpmPmQCtsbkvWIR,iv:MHBR+/phj8I9CgXGmkRglC6vBXD8ZtM7GSB12lc9DP0=,tag:zeXn9c7ZiZ0gZa6TKOdehQ==,type:str]
+    slack-url: ENC[AES256_GCM,data:m9IxT0wjhEkObhkkwTxHin7qS5w5LFjk+EIMcc9CdgVRsKiHx8VJvUTvGA2GMSN1xpRHcaog8jH7OArEGU/s+WsjmfTt8RKXU5YBqAL0oPoorHW6XFk5wG9Q1EMyGeMh1Nk/+4GVfQfaXUx2,iv:bQxwAvYh4NDRndEtyetolvDNRPWrruAXDAcbCiRStxQ=,tag:wxFPpDkIQlCsEjm3Xgp+KQ==,type:str]
 kind: Secret
 metadata:
     name: slack-webhook-url
@@ -76,14 +76,14 @@ type: Opaque
 sops:
     kms: []
     gcp_kms:
-        - resource_id: projects/phx-01h4rr1468rj3v5k60b1vserd3/locations/northamerica-northeast1/keyRings/sops/cryptoKeys/sops-key
-          created_at: "2023-12-12T18:45:36Z"
-          enc: CiQABjWkUI/cDqGciCkvX2TljiXkDNnm7I5mM1kqs4Px2Qc0ESUSSQB/rzHLa302yTHjS0tBM/95N9PDTeG4zhyYdUQ/GJYx4v2hZmrloAmPRD5Ioz4GbI2Zg1UgWvR9y8DaUWxX/ptdknTLVrfMDZU=
+        - resource_id: projects/pht-01hp04dtnkf/locations/northamerica-northeast1/keyRings/sops/cryptoKeys/sops-flux-key
+          created_at: "2024-02-08T13:33:46Z"
+          enc: CiQA5+PIYjf21HETzAuNArBQq3w0zqeuHki4yWgYbu8OPUVlQ80SSAD25I1PiU1mX6HIE1CiVEts57EArGPUwn08bzf30s2Z0/ynnn7wb1eNG7DZMJvFsgfQcaXn8GbiMQ+++Hq+Dnr77jK+d1PAAw==
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-12-19T21:03:59Z"
-    mac: ENC[AES256_GCM,data:BRJcQP5Sh3qu79HGeEHcjGpl8EHr5n7XUTLKL97wVLNP3spYIvO+ZMwHDIQoRtCGJbEXQ7Fv1kQ7QZtRmDZ0QnqQjimpMI+DbxgCZ2WIN4J0WsMO5WprcxDcxWlv4Lp2/diz70mWM9LjCAfwk7jozFY3RToul39p8YrJf389Bwg=,iv:cW80U87J+keQY403gam/39BylEV7BO0wzqoSa+ItPBs=,tag:tGCFcFdpX5+yuSbqjyddRA==,type:str]
+    lastmodified: "2024-02-08T13:33:46Z"
+    mac: ENC[AES256_GCM,data:tan9J7/dBC15Y0OL6zvKn/UcOdi9BuZmmcED6MV+AWzK3jXR2v7GgfPDATCw6cAcpZDOtzA9rNDZYgdFgQ6ljrZ2R8KVmTTRjoFA9Co8ZEBCg6+BMsNQe+T2UD7Pi3ISZ5+zHNvQFAdVdOe8IxZu2uIPIzsi6ajUyLTnxDuDGgk=,iv:DyRRJW66s84h68Ob8D/Giu7r584rdCPKC15CKKsGDOs=,tag:Cw+D9ATxwdWK4/GFiGQ1GA==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.8.1

--- a/k8s/server/overlays/prod/postgres/kustomization.yaml
+++ b/k8s/server/overlays/prod/postgres/kustomization.yaml
@@ -15,3 +15,4 @@ patches:
 # see https://github.com/kubernetes-sigs/kustomize/blob/master/examples/transformerconfigs/README.md#labels-transformer
 commonLabels:
   app: server
+  branch: main

--- a/k8s/server/overlays/prod/postgres/kustomization.yaml
+++ b/k8s/server/overlays/prod/postgres/kustomization.yaml
@@ -14,5 +14,5 @@ patches:
 # use a labelTransformer directive if you need to propagate a label only to the label field
 # see https://github.com/kubernetes-sigs/kustomize/blob/master/examples/transformerconfigs/README.md#labels-transformer
 commonLabels:
-  app: server
+  app: database
   branch: main

--- a/k8s/server/overlays/prod/postgres/pg-cluster.yaml
+++ b/k8s/server/overlays/prod/postgres/pg-cluster.yaml
@@ -7,9 +7,6 @@ spec:
   startDelay: 900
   stopDelay: 900
 
-# PostGres Best Practices for the Logging 
-  #  - https://www.enterprisedb.com/blog/how-get-best-out-postgresql-logs
-  #  - https://medium.com/google-cloud/correlate-statement-logs-in-cloudsql-for-postgres-with-connection-sessions-5bae4ade38f5
   postgresql:
     pg_hba:
       - host all all all md5
@@ -28,17 +25,17 @@ spec:
       annotations:
         # k8s service account is created with the same as `metadata.name` above
         # ensure an appropriate storage role(s) and workload identity is assigned: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
-        iam.gke.io/gcp-service-account: hopicpostgresbackup@phx-01h4rr1468rj3v5k60b1vserd3.iam.gserviceaccount.com
+        iam.gke.io/gcp-service-account: hopic-postgres-backup@pht-01hp04dtnkf.iam.gserviceaccount.com
 
   # info: https://cloudnative-pg.io/documentation/1.21/appendixes/object_stores/#running-inside-google-kubernetes-engine
   backup:
     barmanObjectStore:
-      destinationPath: gs://hopic-dev-postgres-backup
+      destinationPath: gs://hopic-postgres-backup-01hp04dtnkf
       googleCredentials:
         gkeEnvironment: true
     retentionPolicy: "30d"
 
   resources:
     requests:
-      cpu: 450m
-      memory: 1926Mi
+      cpu: 200m # + `isito-proxy` container = 250m
+      memory: 500Mi # + `isito-proxy` container = 612MiB

--- a/k8s/server/overlays/prod/postgres/restore/restore-from-k8s-backup-object.yaml
+++ b/k8s/server/overlays/prod/postgres/restore/restore-from-k8s-backup-object.yaml
@@ -61,7 +61,7 @@ spec:
       annotations:
         # k8s service account is created with the same as `metadata.name` above
         # ensure an appropriate storage role(s) and workload identity is assigned: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
-        iam.gke.io/gcp-service-account: hopicpostgresbackup@phx-01h4rr1468rj3v5k60b1vserd3.iam.gserviceaccount.com
+        iam.gke.io/gcp-service-account: hopicpostgresbackup@pht-01hp04dtnkf.iam.gserviceaccount.com
 
   backup:
     barmanObjectStore:

--- a/k8s/server/overlays/prod/postgres/restore/restore-from-live-cluster.yaml
+++ b/k8s/server/overlays/prod/postgres/restore/restore-from-live-cluster.yaml
@@ -56,7 +56,7 @@ spec:
       annotations:
         # k8s service account is created with the same as `metadata.name` above
         # ensure an appropriate storage role(s) and workload identity is assigned: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
-        iam.gke.io/gcp-service-account: hopicpostgresbackup@phx-01h4rr1468rj3v5k60b1vserd3.iam.gserviceaccount.com	
+        iam.gke.io/gcp-service-account: hopicpostgresbackup@pht-01hp04dtnkf.iam.gserviceaccount.com	
 
   backup:
     barmanObjectStore:

--- a/k8s/server/overlays/prod/postgres/restore/restore-from-object-storage.yaml
+++ b/k8s/server/overlays/prod/postgres/restore/restore-from-object-storage.yaml
@@ -2,10 +2,10 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: cpho-postgres14-cluster-restore
+  name: cpho-postgres14-cluster
   namespace: server
   labels:
-    app: postgres14-cluster
+    app: database
   annotations:
     proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
 spec:
@@ -58,14 +58,14 @@ spec:
       annotations:
         # k8s service account is created with the same as `metadata.name` above
         # ensure an appropriate storage role(s) and workload identity is assigned: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
-        iam.gke.io/gcp-service-account: hopicpostgresbackup@phx-01h4rr1468rj3v5k60b1vserd3.iam.gserviceaccount.com	
+        iam.gke.io/gcp-service-account: hopic-postgres-backup@pht-01hp04dtnkf.iam.gserviceaccount.com
 
-  backup:
-    barmanObjectStore:
-      destinationPath: gs://hopic-dev-postgres-backup
-      googleCredentials:
-        gkeEnvironment: true
-    retentionPolicy: "30d"	
+  # backup:
+  #   barmanObjectStore:
+  #     destinationPath: gs://hopic-dev-postgres-backup
+  #     googleCredentials:
+  #       gkeEnvironment: true
+  #   retentionPolicy: "30d"	
 
   externalClusters:
     - name: cpho-postgres-restore

--- a/k8s/server/overlays/prod/sync.yaml
+++ b/k8s/server/overlays/prod/sync.yaml
@@ -53,7 +53,7 @@ metadata:
   name: server
   namespace: flux-system
 spec:
-  image: northamerica-northeast1-docker.pkg.dev/phx-01h4rr1468rj3v5k60b1vserd3/cpho-phase2-artifact-registry-for-cloud-run/cpho-phase2
+  image: northamerica-northeast1-docker.pkg.dev/pht-01hp04dtnkf/hopic-k8s-images/cpho-phase2
   interval: 1m0s
   provider: gcp
 ---


### PR DESCRIPTION
- Update `cnpg-system` CRDs
- Update project specific dependencies - project-ids, service account names and re-encrypt secrets.
- Add a `ConfigMap` resource for storing configurations. This is referenced in the **overlay** deployments (not in base) via a `envFrom` key
- Update resources for server pod.
   Since the minimum resources for the server pod was causing a scale-up by the HPA in our old cluster, I've bumped up the resources a bit to ensure there's only one replica. The HPA would still "kick-in" if there's a spike in traffic.
- Update resources for postgres cluster pods
   Don't exactly remember why but the postgres cluster pods were using `1926Mi` memory. Based on the utilization from the old cluster, I've dialed down the cpu / memory on this.
- Move resources for `istio-proxy` container to base deployment spec.

Depends on #196.