### PR TITLE
Configure ASM and cert-manager for noble

### DIFF
--- a/k8s/cert-manager/crds/kustomization.yaml
+++ b/k8s/cert-manager/crds/kustomization.yaml
@@ -35,9 +35,7 @@ patches:
           requests:
             cpu: 250m
             memory: 512Mi
-
             
-  # Patch for cert-manager-cainjector with Chainguard image
   - target:
       group: apps
       version: v1
@@ -57,7 +55,6 @@ patches:
             cpu: 250m
             memory: 512Mi
 
-    # Patch for cert-manager-webhook with Chainguard image
   - target:
       group: apps
       version: v1
@@ -71,7 +68,6 @@ patches:
           requests:
             cpu: 250m
             memory: 512Mi
-
 
   - target:
       kind: "(Role|RoleBinding)"

--- a/k8s/cert-manager/crds/kustomization.yaml
+++ b/k8s/cert-manager/crds/kustomization.yaml
@@ -93,4 +93,4 @@ patches:
       - op: add
         path: "/metadata/annotations"
         value:
-          iam.gke.io/gcp-service-account: dns01-solver@pht-01hhjj7tt0m.iam.gserviceaccount.com
+          iam.gke.io/gcp-service-account: dns01-solver@pht-01hp04dtnkf.iam.gserviceaccount.com

--- a/k8s/cert-manager/kustomization.yaml
+++ b/k8s/cert-manager/kustomization.yaml
@@ -15,7 +15,7 @@ patches:
         selector: {}
         dns01:
           cloudDNS:
-            project: pht-01hhjj7tt0m
+            project: pht-01hp04dtnkf
 
 - target:
     group: cert-manager.io

--- a/k8s/istio-ingress/gw-certificate.yaml
+++ b/k8s/istio-ingress/gw-certificate.yaml
@@ -1,0 +1,17 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: gateway-cert
+  namespace: istio-ingress
+spec:
+  dnsNames:
+    - hopic-sdpac.phac-aspc.alpha.canada.ca
+  issuerRef:
+    kind: ClusterIssuer
+    # name: letsencrypt-staging
+    name: letsencrypt
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS8
+    size: 4096
+  secretName: tlskeys

--- a/k8s/istio-ingress/kustomization.yaml
+++ b/k8s/istio-ingress/kustomization.yaml
@@ -11,7 +11,7 @@ patches:
 - patch: |-
     - op: add
       path: /spec/loadBalancerIP
-      value: 34.152.0.41
+      value: 35.203.101.160
   target:
     kind: Service
     name: istio-ingressgateway

--- a/k8s/istio-ingress/kustomization.yaml
+++ b/k8s/istio-ingress/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+- gw-certificate.yaml
 - public-gateway.yaml
 - ingress.yaml
 - namespace.yaml

--- a/k8s/istio-ingress/sync.yaml
+++ b/k8s/istio-ingress/sync.yaml
@@ -13,4 +13,4 @@ spec:
     name: flux-system
   wait: true
   dependsOn:
-    - name: flux-system
+    - name: cert-manager-resources


### PR DESCRIPTION
- Update project specific dependencies - project-ids, service account names and load balancer ip.
- Update dependency order
   Initially `cert-manager` used to depend on the `istio-ingress` ks, however, this has now been reversed due to fact that we expect the certificate secret to be created before gateway configuration can consume it.
- Clean up comments

Depends on https://github.com/PHACDataHub/dns/pull/56 to work.