### PR TITLE
Configure infrastructure for NIST compliance

### DIFF
--- a/infrastructure/cloudbuild.yaml
+++ b/infrastructure/cloudbuild.yaml
@@ -16,3 +16,4 @@ spec:
       branch: .*
   ignoredFiles:
     - "k8s/**"
+    - "infrastructure/**"

--- a/infrastructure/iam-audit-logs.yaml
+++ b/infrastructure/iam-audit-logs.yaml
@@ -1,0 +1,14 @@
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMAuditConfig
+metadata:
+  name: hopic-iamauditconfig
+  namespace: cnrm-system
+spec:
+  service: allServices
+  auditLogConfigs:
+    - logType: ADMIN_READ
+    - logType: DATA_WRITE
+    - logType: DATA_READ
+  resourceRef:
+    kind: Project
+    external: projects/pht-01hp04dtnkf

--- a/infrastructure/kms.yaml
+++ b/infrastructure/kms.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   keyRingRef:
     name: sops
+  # needs to be seconds as per https://cloud.google.com/config-connector/docs/reference/resource-docs/kms/kmscryptokey#spec
+  rotationPeriod: 5184000s # 60days
 ---
 apiVersion: kms.cnrm.cloud.google.com/v1beta1
 kind: KMSKeyRing

--- a/k8s/Taskfile.yaml
+++ b/k8s/Taskfile.yaml
@@ -20,7 +20,8 @@ tasks:
           --bgp-routing-mode=regional --mtu=1460 --project={{.PROJECT_ID}}
       - |
         gcloud compute networks subnets create {{.NAME}}-subnet --network={{.NAME}}-net \
-          --range=10.162.0.0/20 --region={{.REGION}} --project={{.PROJECT_ID}}
+          --range=10.162.0.0/20 --region={{.REGION}} --enable-flow-logs \
+          --project={{.PROJECT_ID}}
       - |
         gcloud beta container --project={{.PROJECT_ID}} clusters create-auto {{.NAME}} \
           --region={{.REGION}} --release-channel "regular" \


### PR DESCRIPTION
As per the recommendations for NIST compliance in the GCP's security command center -
- Set key rotation period to 60 days
  As per https://github.com/getsops/sops/issues/1135#issuecomment-1731811794, it shouldn't cause any issues to existing secrets when a key is rotated.
- Enable flow logs on subnet
  I "clickops-ed" this because it's not a part of IaD, however, added the relevant flag to `k8s/Taskfile` command for future use.
- Enable IAM Audit logs

In addition to this, the `infrastructure/` directory is added to the cloudbuild trigger's ignored files.