### PR TITLE
Enable security posture

### DIFF
--- a/infrastructure/api.yaml
+++ b/infrastructure/api.yaml
@@ -81,3 +81,16 @@ spec:
   projectRef:
     external: projects/pht-01hp04dtnkf
   resourceID: secretmanager.googleapis.com
+---
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: containersecurity
+  namespace: cnrm-system
+  annotations:
+    cnrm.cloud.google.com/disable-dependent-services: "false"
+spec:
+  projectRef:
+    external: projects/pht-01hp04dtnkf
+  resourceID: containersecurity.googleapis.com
+

--- a/k8s/server/base/django/deployment.yaml
+++ b/k8s/server/base/django/deployment.yaml
@@ -22,6 +22,8 @@ spec:
       - name: server
         securityContext:
           runAsUser: 5678
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
         env:
         - name: SECRET_KEY
           valueFrom:

--- a/k8s/server/base/django/deployment.yaml
+++ b/k8s/server/base/django/deployment.yaml
@@ -9,6 +9,8 @@ spec:
       annotations:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
     spec:
+      securityContext:
+        runAsNonRoot: true
       containers:
         # istio-proxies are injected by anthos, see `istio.io/rev: asm-managed` in ../namespace.yaml
         # these are overrides for the default configuration of those injected proxy sidecars
@@ -22,7 +24,6 @@ spec:
       - name: server
         securityContext:
           runAsUser: 5678
-          runAsNonRoot: true
           allowPrivilegeEscalation: false
         env:
         - name: SECRET_KEY


### PR DESCRIPTION
- Enable API to view security posture dashboard for the cluster.
- Set `runAsNonRoot` and `allowPrivilegeEscalation` fields on the server pod based on the recommendations from the security posture dashboard.