### PR TITLE
Add `allowPrivilegeEscalation` to deployments

### DIFF
--- a/k8s/cnpg-system/kustomization.yaml
+++ b/k8s/cnpg-system/kustomization.yaml
@@ -35,6 +35,8 @@ patches:
                   requests:
                     cpu: 50m
                     memory: 112Mi   
+                securityContext:
+                  allowPrivilegeEscalation: false
     target:
       kind: Deployment
       name: cnpg-controller-manager

--- a/k8s/server/base/django/deployment.yaml
+++ b/k8s/server/base/django/deployment.yaml
@@ -21,6 +21,8 @@ spec:
             # Experiment: using the minimum pod resources https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#compute-class-min-max
             cpu: 50m # + `server` container = 250m
             memory: 112Mi # + `server` container = 512MiB
+        securityContext:
+          allowPrivilegeEscalation: false
       - name: server
         securityContext:
           runAsUser: 5678


### PR DESCRIPTION
Even after merging https://github.com/PHACDataHub/cpho-phase2/pull/199, the security posture dashboard tagged `cnpg-controller-manager` and `server` deployments as misconfigurations under `pod container allows privilege escalations on exec`.

This was due to missing `allowPrivilegeEscalation` field for the `istio-proxy` container in the deployment spec (thanks to @simardeep1792 for pointing this). The alert technically is a false positive because the pods created by these deployments still have the `allowPrivilegeEscalation` field set. 

In any case, this PR explicitly sets the security context for `istio-proxy` containers to clean up the dashboard.