### PR TITLE
Fix server container crashing on newly created pods

### DIFF
--- a/server/gunicorn.conf.py
+++ b/server/gunicorn.conf.py
@@ -1,7 +1,5 @@
 import os
 
-from server.open_telemetry_util import instrument_app_for_open_telemetry
-
 # See https://cloud.google.com/run/docs/tips/python#optimize_gunicorn
 
 PORT = os.getenv("PORT", "8080")

--- a/server/server/open_telemetry_util.py
+++ b/server/server/open_telemetry_util.py
@@ -102,8 +102,9 @@ def instrument_app_for_open_telemetry():
         # Manually call detect and merge as needed instead, not a big deal, this only happens once
         # and isn't CPU intensive at all.
         # Note: for merge, the order matters with priority given to preceding resource objects
-        resource = GoogleCloudResourceDetector(raise_on_error=True).detect()
-        resource.merge(ProcessResourceDetector(raise_on_error=True).detect())
+        resource = (
+            GoogleCloudResourceDetector(raise_on_error=True).detect()
+        ).merge(ProcessResourceDetector(raise_on_error=True).detect())
 
     # Propagate the X-Cloud-Trace-Context header if present. Add it otherwise
     set_global_textmap(CloudTraceFormatPropagator())

--- a/server/server/open_telemetry_util.py
+++ b/server/server/open_telemetry_util.py
@@ -1,5 +1,7 @@
+import logging
 import os
 import sys
+import time
 
 import requests
 from opentelemetry import trace
@@ -25,6 +27,8 @@ from phac_aspc.django.helpers.logging.utils import (
 
 from server.config_util import get_project_config, is_running_tests
 
+logger = logging.getLogger()
+
 
 def instrument_app_for_open_telemetry():
     config = get_project_config()
@@ -47,10 +51,41 @@ def instrument_app_for_open_telemetry():
 
         resource = ProcessResourceDetector(raise_on_error=True).detect()
     else:
-        project_id = requests.get(
-            "http://metadata.google.internal/computeMetadata/v1/project/project-id",
-            headers={"Metadata-Flavor": "Google"},
-        ).text
+        # In Google Cloud, we must request resources information from a metadata server (metadata.google.internal).
+        # In theory this is consistently reachable across GCP solutions (Cloud Run, App Engine, GKE, etc),
+        # but in practice there's a big gotcha in GKE. New pods do not immediately have access to the metadata
+        # server, and may not for a "few seconds" according to the docs linked below.
+        # https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity#project_metadata
+        #
+        # Open telemetry "resource" information is used to identify the source of a span, and is imutable once
+        # the corresponding trace provider has been initialized... which all needs to happen before the Django server
+        # is initialized. This is all not ideal for cold start times! Not the slowest part though, running collect static
+        # and migrations on pod start is a bigger slow down right now. Retrying the metadata.google.internal request with
+        # a short linear delay is the best solution for now. Don't bother with exponential backoff because we want to know
+        # asap and aren't worried about load on the metadata server (in theory; something to keep an eye on in practice).
+        #
+        # Note: we directly call metadata.google.internal below for the project ID, which _could_ be passed as
+        # an env var, _but_ the GoogleCloudResourceDetector call following that also requires metadata server
+        # access. GoogleCloudResourceDetector doesn't have the logic to wait for the metadata server so we need to
+        # implement logic to wait for metadata.google.internal access our selves either way.
+        retry_limit = 12
+        retry_delay = 0.25
+
+        logger.info("Attempting to connect to Google Cloud metadata server...")
+        for retry_count in range(retry_limit):
+            try:
+                project_id = requests.get(
+                    "http://metadata.google.internal/computeMetadata/v1/project/project-id",
+                    headers={"Metadata-Flavor": "Google"},
+                ).text
+
+                break
+            except requests.ConnectionError as error:
+                if retry_count < retry_limit - 1:
+                    time.sleep(retry_delay)
+                else:
+                    raise error
+        logger.info("Metadata server reachable!")
 
         span_exporter = CloudTraceSpanExporter(
             project_id=project_id,


### PR DESCRIPTION
When new server pods are created in the cluster, they server container currently crashes and reboots once or twice before sorting itself out. Turns out this is related to (but not the solution to) our Cloud Traces having been broken ever since we switched to GKE. 

Details are in code comments, in short though we need to retrieve metadata from `metadata.google.internal` before we configure tracing. All google cloud compute resources (App Engine, Cloud Run, etc) can make calls to that internal metadata endpoint to get information about themselves, but there's a gotcha in GKE (of course). In GKE, the `metadata.google.internal` domain resolves to the cluster's own metadata server, but this metadata server can't accept traffic from new pods for "a few seconds" while the cluster sorts itself out. Early calls are rejected, and were previously causing the server container inside the pod to crash and restart once or twice before succeeding.

Delayed request retries should fix this, and be more efficient than letting the whole container crash-and-retry. Of course, this is still fundamentally a pain point for pod cold starts, ugh.

Retry limit and delay period may need tweaking in practice, ~TBD~. **Edit:** tested these in the ephemeral environment I was using to debug another tracing related issue, the current timeout periods work :+1:.

I've slipped in a very minor tracing related fix in here as well, pretty much trivial.