### PR TITLE
Add K8s and cloud permissions for server deployment

### DIFF
--- a/infrastructure/iam-mapping.yaml
+++ b/infrastructure/iam-mapping.yaml
@@ -9,6 +9,11 @@ spec:
     - members:
         - memberFrom:
             serviceAccountRef:
+              name: server-deployment
+      role: roles/cloudtrace.agent
+    - members:
+        - memberFrom:
+            serviceAccountRef:
               name: gcr-credentials-sync
       role: roles/artifactregistry.reader
     - members:
@@ -133,3 +138,18 @@ spec:
     apiVersion: iam.cnrm.cloud.google.com/v1beta1
     kind: IAMServiceAccount
     name: hopic-postgres-backup
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPartialPolicy
+metadata:
+  name: hopic-wi-server
+  namespace: "cnrm-system"
+spec:
+  bindings:
+    - members:
+        - member: serviceAccount:pht-01hp04dtnkf.svc.id.goog[server/server]
+      role: roles/iam.workloadIdentityUser
+  resourceRef:
+    apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMServiceAccount
+    name: server-deployment

--- a/infrastructure/service-account.yaml
+++ b/infrastructure/service-account.yaml
@@ -33,3 +33,12 @@ metadata:
 spec:
   displayName: sops-kms
   description: To decrypt secrets within flux kustomize controller
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMServiceAccount
+metadata:
+  name: server-deployment
+  namespace: cnrm-system
+spec:
+  displayName: server-deployment
+  description: To assign cloud permissions for server deployment in GKE

--- a/k8s/server/base/django/deployment.yaml
+++ b/k8s/server/base/django/deployment.yaml
@@ -9,6 +9,7 @@ spec:
       annotations:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
     spec:
+      serviceAccountName: server
       securityContext:
         runAsNonRoot: true
       containers:

--- a/k8s/server/base/django/kustomization.yaml
+++ b/k8s/server/base/django/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
 - deployment.yaml
 - service.yaml
+- service-account.yaml
 

--- a/k8s/server/base/django/service-account.yaml
+++ b/k8s/server/base/django/service-account.yaml
@@ -1,6 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    iam.gke.io/gcp-service-account: server-deployment@pht-01hp04dtnkf.iam.gserviceaccount.com
   name: server

--- a/k8s/server/base/django/service-account.yaml
+++ b/k8s/server/base/django/service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: server-deployment@pht-01hp04dtnkf.iam.gserviceaccount.com
+  name: server

--- a/k8s/server/overlays/prod/django/kustomization.yaml
+++ b/k8s/server/overlays/prod/django/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 
 patches:
   - path: deployment.yaml
+  - path: service-account.yaml
 
 namespace: server
 

--- a/k8s/server/overlays/prod/django/service-account.yaml
+++ b/k8s/server/overlays/prod/django/service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: server-deployment@pht-01hp04dtnkf.iam.gserviceaccount.com
+  name: server


### PR DESCRIPTION
- Add a GCP service account for server deployment
  Any permissions for the prod server pod must be assigned to this GCP service account.
- Add `roles/cloudtrace.agent` to fix cloud trace permission issues on server pod.
- Add K8s service account resource with appropriate annotations for workload identity and attach it to `server` deployment.
  Note that the GCP service account annotation is only added to the **prod** server deployment and not the **ephemeral** one due to issues with binding workload identity user permission ephemerally as highlighted in https://github.com/PHACDataHub/cpho-phase2/pull/205#issue-2130770901. Ephemeral deployment pods will use the `server` K8s service account from their respective namespaces but, unlike prod, won't have any permissions on the cloud.