### PR TITLE
Fix unauthenticated redirects from /healthcheck route

### DIFF
--- a/server/server/urls.py
+++ b/server/server/urls.py
@@ -8,6 +8,8 @@ from django.views.decorators.csrf import csrf_exempt
 from api import views as api_views
 from autocomplete import HTMXAutoComplete
 
+from server.middleware import allow_unauthenticated
+
 from cpho.urls import (
     urlpatterns as cpho_urls,  # force an import for runserver's refresh sake
 )
@@ -40,7 +42,11 @@ urlpatterns = i18n_patterns(
     prefix_default_language=False,
 ) + [
     *phac_aspc_helper_urls,
-    path("healthcheck/", lambda r: HttpResponse(), name="simple_healthcheck"),
+    path(
+        "healthcheck/",
+        allow_unauthenticated(lambda r: HttpResponse(status=200)),
+        name="simple_healthcheck",
+    ),
     path(
         "robots.txt",
         lambda r: HttpResponse(

--- a/server/tests/test_healthcheck.py
+++ b/server/tests/test_healthcheck.py
@@ -1,0 +1,10 @@
+from django.test.client import Client
+from django.urls import reverse
+
+
+def test_healthcheck():
+    url = reverse("simple_healthcheck")
+
+    response = Client().get(url, follow=False)
+
+    assert response.status_code == 200


### PR DESCRIPTION
Pretty trivial. Health checks were triggering the unathenticated middleware and getting redirected to the login page. Marking the /healthcheck route as allowing unathenticated traffic prevents that, which reduces the general logging and telemetry noise from healthchecks as well as their impact on server resources. 