### PR TITLE
Add DNS zone for ops

### DIFF
--- a/infrastructure/dns-zone.yaml
+++ b/infrastructure/dns-zone.yaml
@@ -51,3 +51,15 @@ spec:
   rrdatasRefs:
     - name: hopic-external-ip
       kind: ComputeAddress
+---
+apiVersion: dns.cnrm.cloud.google.com/v1beta1
+kind: DNSManagedZone
+metadata:
+  name: hopic-ops-managed-zone
+  namespace: cnrm-system
+spec:
+  cloudLoggingConfig:
+    enableLogging: true
+  description: HoPiC DNS Zone for alpha DNS
+  dnsName: hopic-sdpac.data-donnes.phac-aspc.gc.ca.
+  visibility: public


### PR DESCRIPTION
Add DNS zone for operations hopic endpoint i.e, `hopic-sdpac.data-donnes.phac-aspc.gc.ca`.

This is mostly to get SSO redirect set up with the new URL and test if DNS delegation works in the [upstream project](https://github.com/PHACDataHub/phac-dns).