### PR TITLE
Configure cloud armor policy

### DIFF
--- a/infrastructure/backend-service.yaml
+++ b/infrastructure/backend-service.yaml
@@ -1,0 +1,27 @@
+# Due to limitations of GKE's Gateway API, a cloud armor security policy for the
+# regional XLB's backend service cannot be configured via the k8s gateway spec.
+# The workaround, therefore, is to add the policy to the backend-service directly by
+# importing the backend service resource into KCC.
+
+# This file is not synced by Flux
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeBackendService
+metadata:
+  annotations:
+    cnrm.cloud.google.com/project-id: pht-01hp04dtnkf
+  name: gkegw1-iswp-istio-ingress-istio-ingressgatewa-8443-6xz70r427d78
+spec:
+  connectionDrainingTimeoutSec: 0
+  healthChecks:
+  - healthCheckRef:
+      external: https://www.googleapis.com/compute/v1/projects/pht-01hp04dtnkf/regions/northamerica-northeast1/healthChecks/gkegw1-iswp-istio-ingress-istio-ingressgatewa-8443-6xz70r427d78
+  loadBalancingScheme: EXTERNAL_MANAGED
+  localityLbPolicy: ROUND_ROBIN
+  location: northamerica-northeast1
+  portName: http
+  protocol: HTTPS
+  resourceID: gkegw1-iswp-istio-ingress-istio-ingressgatewa-8443-6xz70r427d78
+  securityPolicy: https://www.googleapis.com/compute/beta/projects/pht-01hp04dtnkf/regions/northamerica-northeast1/securityPolicies/hopic-waf
+  sessionAffinity: NONE
+  timeoutSec: 30

--- a/infrastructure/backend-service.yaml
+++ b/infrastructure/backend-service.yaml
@@ -1,3 +1,7 @@
+# Due to limitations of GKE's Gateway API, a cloud armor security policy for the
+# regional XLB's backend service cannot be configured via the k8s gateway spec.
+# The workaround, therefore, is to add the policy to the backend-service directly by
+# importing the backend service resource into KCC.
 ---
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeBackendService

--- a/infrastructure/backend-service.yaml
+++ b/infrastructure/backend-service.yaml
@@ -1,9 +1,3 @@
-# Due to limitations of GKE's Gateway API, a cloud armor security policy for the
-# regional XLB's backend service cannot be configured via the k8s gateway spec.
-# The workaround, therefore, is to add the policy to the backend-service directly by
-# importing the backend service resource into KCC.
-
-# This file is not synced by Flux
 ---
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeBackendService
@@ -17,8 +11,10 @@ spec:
   - healthCheckRef:
       external: https://www.googleapis.com/compute/v1/projects/pht-01hp04dtnkf/regions/northamerica-northeast1/healthChecks/gkegw1-iswp-istio-ingress-istio-ingressgatewa-8443-6xz70r427d78
   loadBalancingScheme: EXTERNAL_MANAGED
-  localityLbPolicy: ROUND_ROBIN
   location: northamerica-northeast1
+  logConfig:
+    enable: true
+    sampleRate: 1
   portName: http
   protocol: HTTPS
   resourceID: gkegw1-iswp-istio-ingress-istio-ingressgatewa-8443-6xz70r427d78

--- a/infrastructure/backend-service.yaml
+++ b/infrastructure/backend-service.yaml
@@ -2,6 +2,8 @@
 # regional XLB's backend service cannot be configured via the k8s gateway spec.
 # The workaround, therefore, is to add the policy to the backend-service directly by
 # importing the backend service resource into KCC.
+#
+# As mentioned above, this resource was imported via KCC. DO NOT MODIFY DIRECTLY
 ---
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeBackendService

--- a/infrastructure/backend-service.yaml
+++ b/infrastructure/backend-service.yaml
@@ -2,9 +2,8 @@
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeBackendService
 metadata:
-  annotations:
-    cnrm.cloud.google.com/project-id: pht-01hp04dtnkf
   name: gkegw1-iswp-istio-ingress-istio-ingressgatewa-8443-6xz70r427d78
+  namespace: cnrm-system
 spec:
   connectionDrainingTimeoutSec: 0
   healthChecks:

--- a/infrastructure/kustomization.yaml
+++ b/infrastructure/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - iam-mapping.yaml
 - kms.yaml
 - proxy-subnet.yaml
+- backend-service.yaml
 
 commonLabels:
   classification: ucll

--- a/k8s/Taskfile.yaml
+++ b/k8s/Taskfile.yaml
@@ -80,11 +80,11 @@ tasks:
          preconfigured_waf_rules=(
            # opt out of rules for special character limits in cookies (942420, 942421, 942432); lots of false positives from these
            # opt out of rules for SQL injection probing (942330, 942370, 942490); lots of false positives from these
-           "'sqli-v33-stable', {'opt_out_rule_ids': ['owasp-crs-v030301-id942420-sqli', 'owasp-crs-v030301-id942421-sqli', 'owasp-crs-v030301-id942432-sqli', 'owasp-crs-v030301-id942330-sqli', 'owasp-crs-v030301-id942370-sqli', 'owasp-crs-v030301-id942490-sqli']}"
+           "'sqli-v33-stable', {'opt_out_rule_ids': ['owasp-crs-v030301-id942420-sqli', 'owasp-crs-v030301-id942421-sqli', 'owasp-crs-v030301-id942432-sqli', 'owasp-crs-v030301-id942330-sqli', 'owasp-crs-v030301-id942370-sqli', 'owasp-crs-v030301-id942490-sqli', 'owasp-crs-v030301-id942430-sqli', 'owasp-crs-v030301-id942431-sqli']}"
            "'xss-v33-stable'"
            "'lfi-v33-stable'"
            "'rfi-v33-stable'"
-           "'rce-v33-stable'"
+           "'rce-v33-stable', {'opt_out_rule_ids': ['owasp-crs-v030301-id932200-rce']}"
            "'methodenforcement-v33-stable'"
            "'scannerdetection-v33-stable'"
            "'protocolattack-v33-stable'"

--- a/k8s/istio-ingress/xlb-gateway.yaml
+++ b/k8s/istio-ingress/xlb-gateway.yaml
@@ -1,4 +1,7 @@
 # Regional XLB configuration
+# 
+# Note: The ./infrastructure/backend-service.yaml must be re-imported if this file is edited. 
+# See https://github.com/PHACDataHub/cpho-phase2/pull/225 for details
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:

--- a/k8s/istio-ingress/xlb-httproute.yaml
+++ b/k8s/istio-ingress/xlb-httproute.yaml
@@ -1,4 +1,7 @@
 # HTTP -> HTTPS redirect. See https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/#http-to-https-redirects
+#
+# Note: The ./infrastructure/backend-service.yaml must be re-imported if this file is edited. 
+# See https://github.com/PHACDataHub/cpho-phase2/pull/225 for details
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:

--- a/k8s/istio-ingress/xlb-policy.yaml
+++ b/k8s/istio-ingress/xlb-policy.yaml
@@ -20,11 +20,13 @@ spec:
 apiVersion: networking.gke.io/v1
 kind: GCPBackendPolicy
 metadata:
-  name: hopic-waf
+  name: mesh-gateway-policy
   namespace: istio-ingress
 spec:
   default:
-    securityPolicy: hopic-waf
+    logging:
+      enabled: true
+      sampleRate: 1000000
   targetRef:
     group: ""
     kind: Service

--- a/k8s/istio-ingress/xlb-policy.yaml
+++ b/k8s/istio-ingress/xlb-policy.yaml
@@ -1,3 +1,5 @@
+# Note: The ./infrastructure/backend-service.yaml must be re-imported if this file is edited. 
+# See https://github.com/PHACDataHub/cpho-phase2/pull/225 for details
 apiVersion: networking.gke.io/v1
 kind: HealthCheckPolicy
 metadata:


### PR DESCRIPTION
- Add `ComputeBackendService` resource to bind cloud armor policy to the backend service at an infrastructure level.
   This resource was imported into KCC using the method described [here](https://cloud.google.com/config-connector/docs/how-to/import-export/export#exporting_example). This is a workaround as, [GKE Gateway API doesn't support configuring cloud armor when a regional XLB class is used](https://cloud.google.com/kubernetes-engine/docs/how-to/gatewayclass-capabilities#additional-services).
   In the future, if cloud armor is still unsupported, it'd be better to have this link up configured while provisioning a regional security policy resource. KCC doesn't have this resource yet (See https://github.com/PHACDataHub/cpho-phase2/issues/218).
- Add `GCPBackendPolicy` to enable HTTP logging for the backend service.
  Might be helpful to reduce the `sampleRate` at some point.
- Tune WAF rules for SSO.


Note that, the backend service is controlled by the GKE's gateway configuration (`xlb-` prefixed manifests in `./k8s/istio-ingress/`) and must be modified carefully to avoid a conflicting state since two manifests are reconciling this resource simultaneously -
- GKE gateway configuration
- `ComputeBackendService` IaD configuration

If the gateway configuration is modified, the IaD spec must be regenerated at `./infrastructure/backend-service.yaml`.