### PR TITLE
fix logout url

### DIFF
--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -209,8 +209,9 @@ MIDDLEWARE = configure_middleware(
     ]
 )
 
-LOGIN_URL = reverse_lazy("login")
+LOGOUT_REDIRECT_URL = LOGIN_URL = reverse_lazy("login")
 LOGIN_REDIRECT_URL = reverse_lazy("list_indicators")
+
 
 ROOT_URLCONF = "server.urls"
 APPEND_SLASH = True


### PR DESCRIPTION
in prod, if someone logs out, they get the admin logout screen. If they log back in, it'll give them a 403 because the `?next` would go to the admin
Also fixes #146 