### PR TITLE
Fix sync for `infrastructure/`

### DIFF
--- a/infrastructure/artifactregistry.yaml
+++ b/infrastructure/artifactregistry.yaml
@@ -3,6 +3,8 @@ kind: ArtifactRegistryRepository
 metadata:
   name: hopic-k8s-images
   namespace: cnrm-system
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   description: Artifact registry for HoPiC docker images
   format: DOCKER

--- a/infrastructure/cloudbuildtrigger.yaml
+++ b/infrastructure/cloudbuildtrigger.yaml
@@ -3,6 +3,8 @@ kind: CloudBuildTrigger
 metadata:
   name: hopic-cloudbuild-trigger
   namespace: cnrm-system
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   description: Cloud Build Trigger for building docker images from GitHub repository at https://github.com/PHACDataHub/cpho-phase2/
   disabled: false

--- a/infrastructure/dns-zone.yaml
+++ b/infrastructure/dns-zone.yaml
@@ -3,6 +3,8 @@ kind: DNSManagedZone
 metadata:
   name: hopic-managed-zone
   namespace: cnrm-system
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   cloudLoggingConfig:
     enableLogging: true
@@ -59,6 +61,8 @@ kind: DNSManagedZone
 metadata:
   name: hopic-ops-managed-zone
   namespace: cnrm-system
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   cloudLoggingConfig:
     enableLogging: true

--- a/infrastructure/dns-zone.yaml
+++ b/infrastructure/dns-zone.yaml
@@ -30,6 +30,8 @@ kind: ComputeAddress
 metadata:
   name: hopic-external-ip
   namespace: cnrm-system
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   addressType: EXTERNAL
   description: HoPiC external ip address for ingress gateway

--- a/infrastructure/dns-zone.yaml
+++ b/infrastructure/dns-zone.yaml
@@ -17,6 +17,8 @@ kind: DNSRecordSet
 metadata:
   name: hopic-dns-record-set
   namespace: cnrm-system
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   name: "hopic-sdpac.phac-aspc.alpha.canada.ca."
   type: A
@@ -46,6 +48,8 @@ kind: DNSRecordSet
 metadata:
   name: hopic-ephemeral-dns-record-set
   namespace: cnrm-system
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   name: "*.dev.hopic-sdpac.phac-aspc.alpha.canada.ca."
   type: A

--- a/infrastructure/dnspolicy.yaml
+++ b/infrastructure/dnspolicy.yaml
@@ -3,6 +3,8 @@ kind: DNSPolicy
 metadata:
   name: hopic-net-dnspolicy
   namespace: cnrm-system
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   description: "Enables DNS logging for the hopic-net VPC"
   enableLogging: true

--- a/infrastructure/kms.yaml
+++ b/infrastructure/kms.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: cnrm-system
   annotations:
     cnrm.cloud.google.com/deletion-policy: abandon
+    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   keyRingRef:
     name: sops
@@ -16,5 +17,7 @@ kind: KMSKeyRing
 metadata:
   name: sops
   namespace: cnrm-system
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   location: northamerica-northeast1

--- a/infrastructure/logging-bucket.yaml
+++ b/infrastructure/logging-bucket.yaml
@@ -4,6 +4,8 @@ kind: LoggingLogBucket
 metadata:
   name: hopic-application-logs-pht-01hp04dtnkf
   namespace: cnrm-system
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   projectRef:
     external: "projects/pht-01hp04dtnkf"
@@ -20,6 +22,8 @@ kind: LoggingLogSink
 metadata:
   namespace: cnrm-system
   name: hopic-application-logs-sink
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   projectRef:
     external: "pht-01hp04dtnkf"

--- a/infrastructure/proxy-subnet.yaml
+++ b/infrastructure/proxy-subnet.yaml
@@ -3,6 +3,8 @@ kind: ComputeSubnetwork
 metadata:
   name: proxy-only-subnet
   namespace: cnrm-system
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   ipCidrRange: 10.129.0.0/23
   region: northamerica-northeast1

--- a/infrastructure/service-account.yaml
+++ b/infrastructure/service-account.yaml
@@ -3,6 +3,8 @@ kind: IAMServiceAccount
 metadata:
   name: gcr-credentials-sync
   namespace: cnrm-system
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   displayName: gcr-credentials-sync
   description: To obtain artifact registry credentials for image reconciliations in Flux
@@ -12,6 +14,8 @@ kind: IAMServiceAccount
 metadata:
   name: dns01-solver
   namespace: cnrm-system
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   displayName: dns01-solver
   description: To complete DNS01 Challenge for cert-manager
@@ -21,6 +25,8 @@ kind: IAMServiceAccount
 metadata:
   name: hopic-postgres-backup
   namespace: cnrm-system
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   displayName: hopic-postgres-backup
   description: To backup cloudnative postgres in a gcp bucket
@@ -30,6 +36,8 @@ kind: IAMServiceAccount
 metadata:
   name: sops-kms
   namespace: cnrm-system
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   displayName: sops-kms
   description: To decrypt secrets within flux kustomize controller
@@ -39,6 +47,8 @@ kind: IAMServiceAccount
 metadata:
   name: server-deployment
   namespace: cnrm-system
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   displayName: server-deployment
   description: To assign cloud permissions for server deployment in GKE


### PR DESCRIPTION
Apparently when a dry run is executed by Flux's kustomize controller to apply resources, KCC _thinks_ that Flux is trying to modify an annotation (`cnrm.cloud.google.com/state-into-spec`) and denies the request because the value for that annotation is immutable. This consequently causes the reconciliation to fail.

This PR addresses the issue by explicitly adding the annotation to specific resources that KCC complains about. Some info on what this means and why it's not a disruptive change: https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/669#issuecomment-1339614273.

Essentially we're just setting a default value explicitly.