### PR TITLE
changed text colour to black to meet colour contrast requirements

### DIFF
--- a/server/static/cpho.css
+++ b/server/static/cpho.css
@@ -99,3 +99,11 @@ span.new-ind-tag {
 .django-ckeditor-widget {
     width: 100%;
 }
+
+.badge.bg-info {
+    color: #000;
+}
+
+.badge.bg-warning {
+    color: #000;
+}


### PR DESCRIPTION
In order to meet the 4.5:1 colour contrast requirements I adjusted the text colour for the cyan and yellow backgrounds to black and kept the white text for the green background 