### PR TITLE
Enable network management API

### DIFF
--- a/infrastructure/api.yaml
+++ b/infrastructure/api.yaml
@@ -93,4 +93,16 @@ spec:
   projectRef:
     external: projects/pht-01hp04dtnkf
   resourceID: containersecurity.googleapis.com
+---
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: networkmanagement
+  namespace: cnrm-system
+  annotations:
+    cnrm.cloud.google.com/disable-dependent-services: "false"
+spec:
+  projectRef:
+    external: projects/pht-01hp04dtnkf
+  resourceID: networkmanagement.googleapis.com
 


### PR DESCRIPTION
Enable `networkmanagement.googleapis.com` to try out https://cloud.google.com/network-intelligence-center/docs/network-analyzer/overview?hl=en.