### PR TITLE
French/changelog fix

### DIFF
--- a/server/cpho/text.py
+++ b/server/cpho/text.py
@@ -45,9 +45,9 @@ def tm(key: str) -> str:
     # French fallback to machine translation if the string is not yet translated
     FALLBACK_FLAG = True  # Set to False to disable fallback
     if lang_code == "fr" and FALLBACK_FLAG:
-        if text[lang_map[lang_code]] is None:
+        if text.get(lang_map.get(lang_code)) is None:
             lang_code = "fallback"
-    locale_string = text[lang_map[lang_code]]
+    locale_string = text.get(lang_map.get(lang_code))
     return (
         locale_string
         if locale_string is not None

--- a/server/cpho/translations.py
+++ b/server/cpho/translations.py
@@ -52,27 +52,51 @@ translation_entries = {
     },
     "date": {
         "en": "Date",
+        "fr": "Date",
     },
     "author": {
         "en": "Author",
+        "fr": "Auteur",
     },
     "action": {
         "en": "Action",
+        "fr": "Action",
     },
     "object_type": {
         "en": "Object type",
+        "fr": "Type d'objet",
     },
     "name": {
         "en": "Name",
+        "fr": "Nom",
     },
     "field": {
         "en": "Field",
+        "fr": "Champ",
     },
     "previous_change": {
         "en": "Previous change",
+        "fr": "Valeure précédente",
     },
     "this_change": {
         "en": "This change",
+        "fr": "Valeure après modification",
+    },
+    "no_change_detected_compared_to_previous_version": {
+        "en": "No change detected compared to previous version",
+        "fr": "Aucune modification détectée par rapport à la version précédente",
+    },
+    "of": {
+        "en": "of",
+        "fr": "de",
+    },
+    "first": {
+        "en": "First",
+        "fr": "Premier",
+    },
+    "last": {
+        "en": "Last",
+        "fr": "Dernier",
     },
     "please_login_to_see_page": {
         "en": "Please login to see this page",
@@ -87,5 +111,9 @@ translation_entries = {
     "email_confirmation_exception": {
         "en": "Emails do not match",
         "fr": "Les courriels doivent être identiques",
+    },
+    "changelog": {
+        "en": "Changelog",
+        "fr": "Journal des modifications",
     },
 }


### PR DESCRIPTION
French changelog was crashing because some keys don't have an `fr` entry (it expected at least `None`). Now it tolerates missing keys. Also added the changelog translations, those are copied from app-to-app