### PR TITLE
Increase gateway timeout

### DIFF
--- a/infrastructure/backend-service.yaml
+++ b/infrastructure/backend-service.yaml
@@ -1,3 +1,10 @@
+# Due to limitations of GKE's Gateway API, a cloud armor security policy for the
+# regional XLB's backend service cannot be configured via the k8s gateway spec.
+# The workaround, therefore, is to add the policy to the backend-service directly by
+# importing the backend service resource into KCC.
+#
+# As mentioned above, this resource was imported via KCC. DO NOT MODIFY DIRECTLY
+---
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeBackendService
 metadata:

--- a/infrastructure/backend-service.yaml
+++ b/infrastructure/backend-service.yaml
@@ -1,15 +1,10 @@
-# Due to limitations of GKE's Gateway API, a cloud armor security policy for the
-# regional XLB's backend service cannot be configured via the k8s gateway spec.
-# The workaround, therefore, is to add the policy to the backend-service directly by
-# importing the backend service resource into KCC.
-#
-# As mentioned above, this resource was imported via KCC. DO NOT MODIFY DIRECTLY
----
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeBackendService
 metadata:
   name: gkegw1-iswp-istio-ingress-istio-ingressgatewa-8443-6xz70r427d78
   namespace: cnrm-system
+  annotations:
+    cnrm.cloud.google.com/deletion-policy: abandon
 spec:
   connectionDrainingTimeoutSec: 0
   healthChecks:
@@ -25,4 +20,4 @@ spec:
   resourceID: gkegw1-iswp-istio-ingress-istio-ingressgatewa-8443-6xz70r427d78
   securityPolicy: https://www.googleapis.com/compute/beta/projects/pht-01hp04dtnkf/regions/northamerica-northeast1/securityPolicies/hopic-waf
   sessionAffinity: NONE
-  timeoutSec: 30
+  timeoutSec: 180

--- a/k8s/istio-ingress/xlb-policy.yaml
+++ b/k8s/istio-ingress/xlb-policy.yaml
@@ -26,6 +26,7 @@ metadata:
   namespace: istio-ingress
 spec:
   default:
+    timeoutSec: 180
     logging:
       enabled: true
       sampleRate: 1000000


### PR DESCRIPTION
The upload indicator workflow freezes at an `Uploading data` state due to `504` gateway timeout. 

This PR increases the gateway timeout to 180 seconds so that the server has enough time to respond to the request. In addition to this, sets the `deletion-policy` annotation to `abandon` so that the lifecycle of the backend service is **only** managed by the gateway definition at `./k8s/istio-ingress/xlb-gateway` and not the IaD spec.

In general, if the gateway timeout needs to be edited:
- Pause `infrastructure` and `istio-ingress` flux ks reconciliations
- Delete the `ComputeBackendService` resource from the cluster
   Due to the `deletion-policy` annotation this only deletes the cluster resource and doesn't affect the cloud resource
- Update`timeoutSec` at `./k8s/istio-ingress/xlb-policy` and apply the resource
- Submit a PR with the changes and once merged, resume the reconciliations