### PR TITLE
Pre-prod performance tuning

### DIFF
--- a/server/gunicorn.conf.py
+++ b/server/gunicorn.conf.py
@@ -14,7 +14,10 @@ bind = [f"0.0.0.0:{PORT}"]
 # Our k8s pods only has a fraction of a vCPU currently, so we'll be tuning this by hand
 # Increasing threads doesn't seem to benefit us, likely because we aren't configuring django to be async. For now, explicitly use multiple sync workers
 worker_class = "sync"
-workers = 2
+# With 1 worker (and pre-prod traffic levels), the server pod (.2 vCPU, 500mb RAM) saw idle resource usage of ~5% CPU and ~40% RAM.
+# The larges CPU spikes reached ~40%, but most spikes were only ~15% usage. RAM never spiked. Bumping up to 3 workers for now, to be
+# further tuned based on prod performance.
+workers = 3
 
 
 def post_fork(server, worker):

--- a/server/server/wsgi.py
+++ b/server/server/wsgi.py
@@ -12,11 +12,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-from server.open_telemetry_util import instrument_app_for_open_telemetry
-
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.settings")
-
-flush_telemetry_callback = instrument_app_for_open_telemetry()
-atexit.register(flush_telemetry_callback)
 
 application = get_wsgi_application()


### PR DESCRIPTION
Leaving our server pods on the minimal resources for now, but increasing the gunicorn workers per-pod (from 1 to 3). I expect this to fit based on pre-prod resource usage metrics and local testing, but it'll be something to keep an eye on. Due to the long running data upload requests, concurrency and scaling is necessary to keep the site from going unresponsive under regular use.

We'll also need to tune the cluster appropriately down the road (or maybe the per-pod resources), depending on if this puts the average CPU above the scaling threshold. Expect this to be fine though. @vedantthapa tagging you FYI.

Related #133