### PR TITLE
Increase HPA memory averageUtilization target

### DIFF
--- a/k8s/server/overlays/prod/django/hpa.yaml
+++ b/k8s/server/overlays/prod/django/hpa.yaml
@@ -15,7 +15,9 @@ spec:
       name: memory
       target:
         type: Utilization
-        averageUtilization: 65
+        # memory usage is high due to multiple active gunicorn workers, but tends to remains stable under load,
+        # so a higher average utilization target for scaling is preferable
+        averageUtilization: 85
   - type: Resource
     resource:
       name: cpu


### PR DESCRIPTION
Increase in gunicorn worker count pushed us above pod scaling targets on memory usage, scaled us up to four server pods (which is not necessary). Fine tuning the HPA settings (or, worst case, lowering the workers per pod) should get us a more reasonable baseline.