### PR TITLE
distroless-runtime-and-management-image ephemeral env

### DIFF
--- a/k8s/server/ephemeral-instances/distroless-runtime-and-management-script.yaml
+++ b/k8s/server/ephemeral-instances/distroless-runtime-and-management-script.yaml
@@ -1,0 +1,118 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: distroless
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  ref:
+    branch: distroless-runtime-and-management-image
+  secretRef:
+    name: flux-system
+  url: ssh://git@github.com/PHACDataHub/cpho-phase2
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: distroless-infra
+  namespace: flux-system
+spec:
+  path: ./k8s/server/overlays/ephemeral/infrastructure
+  interval: 2m0s
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: distroless
+  wait: true
+  dependsOn:
+    - name: ephemeral-instances
+  postBuild:
+    substitute:
+      BRANCH_NAME: distroless
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: distroless-postgres
+  namespace: flux-system
+spec:
+  path: ./k8s/server/overlays/ephemeral/postgres
+  interval: 2m0s
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: distroless
+  wait: true
+  dependsOn:
+    - name: distroless-infra
+  postBuild:
+    substitute:
+      BRANCH_NAME: distroless
+
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: distroless-django
+  namespace: flux-system
+spec:
+  interval: 2m0s
+  path: ./k8s/server/overlays/ephemeral/django
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: distroless
+  dependsOn:
+    - name: distroless-postgres
+  decryption:
+    provider: sops
+  postBuild:
+    substitute:
+      BRANCH_NAME: distroless
+---
+# The following manifests are only required if there's a need to enable automated
+# image updates for ephemeral deployments.
+
+# Note that you'll also need to update the policy name in the `$imagepolicy` comment 
+# next to spec.template.spec.image in your branch's server deployment located
+# at ./k8s/server/overlays/ephemeral/django/deployment.yaml
+# See https://fluxcd.io/flux/guides/image-update/ for details
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: distroless-server
+  namespace: flux-system
+spec:
+  filterTags:
+    extract: $ts
+    pattern: ^distroless-[a-fA-F0-9]+-(?P<ts>.*)
+  imageRepositoryRef:
+    name: server
+  policy:
+    numerical:
+      order: asc
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageUpdateAutomation
+metadata:
+  name: distroless-cpho-updater
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: distroless
+  interval: 5m
+  update:
+    strategy: Setters
+    path: .
+  git:
+    checkout:
+      ref:
+        branch: distroless-runtime-and-management-image
+    commit:
+      author:
+        name: fluxbot
+        email: fluxcd@users.noreply.github.com
+      messageTemplate: "[ci skip] {{range .Updated.Images}}{{println .}}{{end}}"
+    push:
+      branch: distroless-runtime-and-management-image

--- a/k8s/server/ephemeral-instances/distroless-runtime-and-management-script.yaml
+++ b/k8s/server/ephemeral-instances/distroless-runtime-and-management-script.yaml
@@ -85,7 +85,7 @@ metadata:
 spec:
   filterTags:
     extract: $ts
-    pattern: ^distroless-[a-fA-F0-9]+-(?P<ts>.*)
+    pattern: ^distroless-runtime-and-management-image-[a-fA-F0-9]+-(?P<ts>.*)
   imageRepositoryRef:
     name: server
   policy:


### PR DESCRIPTION
Add ephemeral env configurations for `distroless-runtime-and-management-image` branch.

Note that you'll need to update the `imagepolicy` comment at https://github.com/PHACDataHub/cpho-phase2/blob/distroless-runtime-and-management-image/k8s/server/overlays/ephemeral/django/deployment.yaml#L10 to `flux-system:distroless-server` to enable automated image updates.