### PR TITLE
Fix healthcheck 301s

### DIFF
--- a/deploy/gcloud_env_vars.sh
+++ b/deploy/gcloud_env_vars.sh
@@ -19,7 +19,7 @@ export PROJECT_ALPHA_SUB_DOMAIN=hopic-sdpac
 export BUILD_GITHUB_REPO_NAME=cpho-phase2
 export BUILD_GITHUB_REPO_OWNER=PHACDataHub
 
-export GITHUB_MAIN_BRANCH_NAME=prod
+export GITHUB_MAIN_BRANCH_NAME=fix-healthcheck
 
 export TEST_COVERAGE_BUCKET_NAME=hopic-test-coverage-reports-01hp04dtnkf
 export TEST_COVERAGE_THRESHOLD=77.5 # set just below current coverage, consider increasing in time

--- a/deploy/gcloud_env_vars.sh
+++ b/deploy/gcloud_env_vars.sh
@@ -19,7 +19,7 @@ export PROJECT_ALPHA_SUB_DOMAIN=hopic-sdpac
 export BUILD_GITHUB_REPO_NAME=cpho-phase2
 export BUILD_GITHUB_REPO_OWNER=PHACDataHub
 
-export GITHUB_MAIN_BRANCH_NAME=fix-healthcheck
+export GITHUB_MAIN_BRANCH_NAME=prod
 
 export TEST_COVERAGE_BUCKET_NAME=hopic-test-coverage-reports-01hp04dtnkf
 export TEST_COVERAGE_THRESHOLD=77.5 # set just below current coverage, consider increasing in time

--- a/k8s/server/base/django/deployment.yaml
+++ b/k8s/server/base/django/deployment.yaml
@@ -71,7 +71,7 @@ spec:
             httpHeaders:
             - name: Host
               value: hopic-sdpac.phac-aspc.alpha.canada.ca
-          initialDelaySeconds: 115
+          initialDelaySeconds: 135
           periodSeconds: 10
           timeoutSeconds: 3
 status: {}

--- a/k8s/server/base/django/deployment.yaml
+++ b/k8s/server/base/django/deployment.yaml
@@ -66,12 +66,12 @@ spec:
               key: microsoft-tenant
         readinessProbe:
           httpGet:
-            path: /healthcheck
+            path: /healthcheck/
             port: 8080
             httpHeaders:
             - name: Host
               value: hopic-sdpac.phac-aspc.alpha.canada.ca
-          initialDelaySeconds: 35
+          initialDelaySeconds: 115
           periodSeconds: 10
           timeoutSeconds: 3
 status: {}

--- a/k8s/server/overlays/ephemeral/django/deployment.yaml
+++ b/k8s/server/overlays/ephemeral/django/deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: northamerica-northeast1-docker.pkg.dev/pht-01hp04dtnkf/hopic-k8s-images/cpho-phase2:prod-98771ce1-1711651460 # {"$imagepolicy": "flux-system:server"}
+        image: northamerica-northeast1-docker.pkg.dev/pht-01hp04dtnkf/hopic-k8s-images/cpho-phase2:prod-98771ce1-1711651460 # {"$imagepolicy": "flux-system:fix-healthcheck-server"}
         resources:
           # Autopilot only considers requests (see https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#resource-limits)
           requests:

--- a/k8s/server/overlays/ephemeral/django/deployment.yaml
+++ b/k8s/server/overlays/ephemeral/django/deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: northamerica-northeast1-docker.pkg.dev/pht-01hp04dtnkf/hopic-k8s-images/cpho-phase2:fix-healthcheck-fb68f011-1713291800 # {"$imagepolicy": "flux-system:fix-healthcheck-server"}
+        image: northamerica-northeast1-docker.pkg.dev/pht-01hp04dtnkf/hopic-k8s-images/cpho-phase2:prod-98771ce1-1711651460 # {"$imagepolicy": "flux-system:server"}
         resources:
           # Autopilot only considers requests (see https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#resource-limits)
           requests:

--- a/k8s/server/overlays/ephemeral/django/deployment.yaml
+++ b/k8s/server/overlays/ephemeral/django/deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: northamerica-northeast1-docker.pkg.dev/pht-01hp04dtnkf/hopic-k8s-images/cpho-phase2:prod-98771ce1-1711651460 # {"$imagepolicy": "flux-system:fix-healthcheck-server"}
+        image: northamerica-northeast1-docker.pkg.dev/pht-01hp04dtnkf/hopic-k8s-images/cpho-phase2:fix-healthcheck-fcded812-1713290747 # {"$imagepolicy": "flux-system:fix-healthcheck-server"}
         resources:
           # Autopilot only considers requests (see https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#resource-limits)
           requests:

--- a/k8s/server/overlays/ephemeral/django/deployment.yaml
+++ b/k8s/server/overlays/ephemeral/django/deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: northamerica-northeast1-docker.pkg.dev/pht-01hp04dtnkf/hopic-k8s-images/cpho-phase2:fix-healthcheck-fcded812-1713290747 # {"$imagepolicy": "flux-system:fix-healthcheck-server"}
+        image: northamerica-northeast1-docker.pkg.dev/pht-01hp04dtnkf/hopic-k8s-images/cpho-phase2:fix-healthcheck-fb68f011-1713291800 # {"$imagepolicy": "flux-system:fix-healthcheck-server"}
         resources:
           # Autopilot only considers requests (see https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#resource-limits)
           requests:

--- a/k8s/server/overlays/ephemeral/django/deployment.yaml
+++ b/k8s/server/overlays/ephemeral/django/deployment.yaml
@@ -17,3 +17,8 @@ spec:
         envFrom:
         - configMapRef:
             name: server
+        readinessProbe:
+          httpGet:
+            httpHeaders:
+            - name: Host
+              value: ${BRANCH_NAME}.dev.hopic-sdpac.phac-aspc.alpha.canada.ca

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -97,6 +97,10 @@ CSRF_TRUSTED_ORIGINS = []
 # Prod only security settings
 if not IS_DEV:
     SECURE_SSL_REDIRECT = True
+    # For K8S Health Check
+    SECURE_REDIRECT_EXEMPT = [
+        '^healthcheck/',
+    ]
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
     SECURE_HSTS_SECONDS = 3600  # TODO this could be set longer, most likely

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -99,7 +99,7 @@ if not IS_DEV:
     SECURE_SSL_REDIRECT = True
     # For K8S Health Check
     SECURE_REDIRECT_EXEMPT = [
-        '^healthcheck/',
+        "^healthcheck/",
     ]
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 


### PR DESCRIPTION
- Increase `initialDelaySeconds` to `135` to delay readiness checks so that the `server` pod has more time to startup
- Fix readiness probe request headers for ephemeral deployments
- Exempt the `healthcheck/` endpoint from secure ssl redirects to fix 301s in the `server` pod