### PR TITLE
fix: disable legacy login

### DIFF
--- a/k8s/server/overlays/prod/django/configmap.yaml
+++ b/k8s/server/overlays/prod/django/configmap.yaml
@@ -9,5 +9,4 @@ data:
   DB_HOST: "cpho-postgres14-cluster-rw"
   DB_PORT: "5432"
   PHAC_ASPC_OAUTH_PROVIDER: "microsoft"
-  ENABLE_LEGACY_LOG_IN: "true" # TODO temporary for dev purposes, not to be used in final prod
   PHAC_ASPC_SESSION_COOKIE_AGE: "259200"


### PR DESCRIPTION
Looks like you did the same [here](https://github.com/PHACDataHub/cpho-phase2/compare/main...disable-login) @vedantthapa , we want this is in prod too. If you'd like to keep legacy login around to test the new domain, that's fine, as long as we turn this off when we finally launch. 