### PR TITLE
fix: make health-check fail when there are pending migrations

### DIFF
--- a/server/server/healthcheck.py
+++ b/server/server/healthcheck.py
@@ -1,0 +1,24 @@
+from django.conf import settings
+from django.db import DEFAULT_DB_ALIAS, connections
+from django.db.migrations.executor import MigrationExecutor
+from django.http import HttpResponse
+
+from server.middleware import allow_unauthenticated
+
+
+def _has_pending_migrations():
+    db_alias = getattr(settings, "HEALTHCHECK_MIGRATIONS_DB", DEFAULT_DB_ALIAS)
+    executor = MigrationExecutor(connections[db_alias])
+    plan = executor.migration_plan(executor.loader.graph.leaf_nodes())
+    if plan:
+        return True
+
+    return False
+
+
+@allow_unauthenticated
+def healthcheck_view(_request):
+    if _has_pending_migrations():
+        return HttpResponse("Database has pending migrations", status=503)
+
+    return HttpResponse(status=200)

--- a/server/server/urls.py
+++ b/server/server/urls.py
@@ -16,6 +16,8 @@ from cpho.views.auth import LoginView, LogoutView, RootView
 
 from api import views as api_views
 
+from .healthcheck import healthcheck_view
+
 dev_routes = []
 if settings.DEBUG and settings.ENABLE_DEBUG_TOOLBAR:
     import debug_toolbar
@@ -45,7 +47,7 @@ urlpatterns = i18n_patterns(
     *phac_aspc_helper_urls,
     path(
         "healthcheck/",
-        allow_unauthenticated(lambda r: HttpResponse(status=200)),
+        healthcheck_view,
         name="simple_healthcheck",
     ),
     path(


### PR DESCRIPTION
The health-check will fail if there are un-applied migrations.

It also passes if migrations are ahead of the source code (e.g. when a new migration is deployed and applied, the old containers still pass this check)