### PR TITLE
feat: configure `maxSurge` for server deployment

### DIFF
--- a/k8s/server/base/django/deployment.yaml
+++ b/k8s/server/base/django/deployment.yaml
@@ -3,7 +3,11 @@ kind: Deployment
 metadata:
   name: server
 spec:
-  strategy: {}
+  strategy:
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Set `maxSurge` to `100%`. [Here's](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#max-surge) some info on what it implies. 

The idea is to roll out newer versions as quickly as possible so that the period where a K8s service load balances requests between old and new versions during a rolling update is reduced. Note that there might be a case where the existing nodes don't have the capacity for all the new pods, as a result, it'll still take a while for the new pods to be ready. In any case, it shouldn't be worse than what we have right now.

All other changes (`strategy.type` and `maxUnavailable`) are set to their defaults.