### PR TITLE
chore: upgrade KCC to v1.116.0

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -140,6 +140,7 @@ To [upgrade config connector](https://cloud.google.com/config-connector/docs/how
 gsutil cp gs://configconnector-operator/latest/release-bundle.tar.gz release-bundle.tar.gz
 tar zxvf release-bundle.tar.gz
 cp ./operator-system/autopilot-configconnector-operator.yaml ./k8s/configconnector-operator-system/
+rm -rf operator-system/ release-bundle.tar.gz
 ```
 
 Once the PR is merged, Flux will propagate the changes. See the [official releases](https://github.com/GoogleCloudPlatform/k8s-config-connector/releases) page for more information regarding an upgrade.

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -137,11 +137,12 @@ Once the PR is merged, Flux will propagate the changes. See the [official releas
 To [upgrade config connector](https://cloud.google.com/config-connector/docs/how-to/install-manually#upgrading) on the cluster, run the following commands from the root of this repository and submit a PR with changes:
 
 ```sh
-gsutil cp gs://configconnector-operator/latest/release-bundle.tar.gz release-bundle.tar.gz
+gsutil cp gs://configconnector-operator/<VERSION>/release-bundle.tar.gz release-bundle.tar.gz
 tar zxvf release-bundle.tar.gz
 cp ./operator-system/autopilot-configconnector-operator.yaml ./k8s/configconnector-operator-system/
 rm -rf operator-system/ release-bundle.tar.gz
 ```
+> Replace `<VERISON>` with a valid KCC Operator version.
 
 Once the PR is merged, Flux will propagate the changes. See the [official releases](https://github.com/GoogleCloudPlatform/k8s-config-connector/releases) page for more information regarding an upgrade.
 

--- a/k8s/configconnector-operator-system/autopilot-configconnector-operator.yaml
+++ b/k8s/configconnector-operator-system/autopilot-configconnector-operator.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.117.0
+    cnrm.cloud.google.com/operator-version: 1.116.0
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: configconnector-operator-system
@@ -11,8 +11,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.117.0
-    controller-gen.kubebuilder.io/version: v0.14.0
+    cnrm.cloud.google.com/operator-version: 1.116.0
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: configconnectorcontexts.core.cnrm.cloud.google.com
@@ -41,19 +42,14 @@ spec:
           API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -61,49 +57,46 @@ spec:
             description: ConfigConnectorContextSpec defines the desired state of ConfigConnectorContext
             properties:
               actuationMode:
-                description: |-
-                  The actuation mode of Config Connector controls how resources are actuated onto the cloud provider.
-                  This can be either 'Reconciling' or 'Paused'. The default is 'Reconciling' where resources get actuated.
-                  In 'Paused', k8s resources are still reconciled with the api server but not actuated onto the cloud provider.
+                description: The actuation mode of Config Connector controls how resources
+                  are actuated onto the cloud provider. This can be either 'Reconciling'
+                  or 'Paused'. The default is 'Reconciling' where resources get actuated.
+                  In 'Paused', k8s resources are still reconciled with the api server
+                  but not actuated onto the cloud provider.
                 enum:
                 - Reconciling
                 - Paused
                 type: string
               billingProject:
-                description: |-
-                  Specifies the project to use for preconditions, quota and billing.
-                  Should only be used when requestProjectPolicy is set to BILLING_PROJECT.
+                description: Specifies the project to use for preconditions, quota
+                  and billing. Should only be used when requestProjectPolicy is set
+                  to BILLING_PROJECT.
                 type: string
               googleServiceAccount:
-                description: |-
-                  The Google Service Account to be used by Config Connector to
-                  authenticate with Google Cloud APIs in the associated namespace.
+                description: The Google Service Account to be used by Config Connector
+                  to authenticate with Google Cloud APIs in the associated namespace.
                 type: string
               requestProjectPolicy:
-                description: |-
-                  Specifies which project to use for preconditions, quota, and billing for
-                  requests made to Google Cloud APIs for resources in the associated
-                  namespace. Must be one of 'SERVICE_ACCOUNT_PROJECT',
-                  'RESOURCE_PROJECT', or 'BILLING_PROJECT. Defaults to 'SERVICE_ACCOUNT_PROJECT'. If set to
-                  'SERVICE_ACCOUNT_PROJECT', uses the project that the Google Service
-                  Account belongs to. If set to 'RESOURCE_PROJECT', uses the project that
-                  the resource belongs to. If set to 'BILLING_PROJECT', uses the project specified by spec.billingProject.
+                description: Specifies which project to use for preconditions, quota,
+                  and billing for requests made to Google Cloud APIs for resources
+                  in the associated namespace. Must be one of 'SERVICE_ACCOUNT_PROJECT',
+                  'RESOURCE_PROJECT', or 'BILLING_PROJECT. Defaults to 'SERVICE_ACCOUNT_PROJECT'.
+                  If set to 'SERVICE_ACCOUNT_PROJECT', uses the project that the Google
+                  Service Account belongs to. If set to 'RESOURCE_PROJECT', uses the
+                  project that the resource belongs to. If set to 'BILLING_PROJECT',
+                  uses the project specified by spec.billingProject.
                 enum:
                 - SERVICE_ACCOUNT_PROJECT
                 - RESOURCE_PROJECT
                 - BILLING_PROJECT
                 type: string
               stateIntoSpec:
-                description: |-
-                  StateIntoSpec is the user override of the default value for the
-                  'cnrm.cloud.google.com/state-into-spec' annotation if the annotation is
-                  unset for a resource.
-                  'Absent' means that unspecified fields in the resource spec stay
-                  unspecified after successful reconciliation.
-                  'Merge' means that unspecified fields in the resource spec are populated
+                description: StateIntoSpec is the user override of the default value
+                  for the 'cnrm.cloud.google.com/state-into-spec' annotation if the
+                  annotation is unset for a resource. 'absent' means that unspecified
+                  fields in the resource spec stay unspecified after successful reconciliation.
+                  'merge' means that unspecified fields in the resource spec are populated
                   after a successful reconciliation if those unspecified fields are
-                  computed/defaulted by the API. It is only applicable to resources
-                  supporting the 'Merge' option.
+                  computed/defaulted by the API.
                 enum:
                 - Absent
                 - Merge
@@ -138,8 +131,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.117.0
-    controller-gen.kubebuilder.io/version: v0.14.0
+    cnrm.cloud.google.com/operator-version: 1.116.0
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: configconnectors.core.cnrm.cloud.google.com
@@ -167,19 +161,14 @@ spec:
         description: ConfigConnector is the Schema for the configconnectors API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -213,57 +202,53 @@ spec:
             description: ConfigConnectorSpec defines the desired state of ConfigConnector
             properties:
               actuationMode:
-                description: |-
-                  The actuation mode of Config Connector controls how resources are actuated onto the cloud provider.
-                  This can be either 'Reconciling' or 'Paused'.
-                  In 'Paused', k8s resources are still reconciled with the api server but not actuated onto the cloud provider.
-                  If Config Connector is running in 'namespaced' mode, then the value in ConfigConnectorContext (CCC) takes precedence.
-                  If CCC doesn't define a value but ConfigConnecor (CC) does, we defer to that value. Otherwise,
-                  the default is 'Reconciling' where resources get actuated.
+                description: The actuation mode of Config Connector controls how resources
+                  are actuated onto the cloud provider. This can be either 'Reconciling'
+                  or 'Paused'. In 'Paused', k8s resources are still reconciled with
+                  the api server but not actuated onto the cloud provider. If Config
+                  Connector is running in 'namespaced' mode, then the value in ConfigConnectorContext
+                  (CCC) takes precedence. If CCC doesn't define a value but ConfigConnecor
+                  (CC) does, we defer to that value. Otherwise, the default is 'Reconciling'
+                  where resources get actuated.
                 enum:
                 - Reconciling
                 - Paused
                 type: string
               credentialSecretName:
-                description: |-
-                  The Kubernetes secret that contains the Google Service Account Key's credentials to be used by ConfigConnector to authenticate with Google Cloud APIs. This field is used only when in cluster mode.
-                  It's recommended to use `googleServiceAccount` when running ConfigConnector in Google Kubernetes Engine (GKE) clusters with Workload Identity enabled.
-                  This field cannot be specified together with `googleServiceAccount`.
+                description: The Kubernetes secret that contains the Google Service
+                  Account Key's credentials to be used by ConfigConnector to authenticate
+                  with Google Cloud APIs. This field is used only when in cluster
+                  mode. It's recommended to use `googleServiceAccount` when running
+                  ConfigConnector in Google Kubernetes Engine (GKE) clusters with
+                  Workload Identity enabled. This field cannot be specified together
+                  with `googleServiceAccount`.
                 type: string
               googleServiceAccount:
-                description: |-
-                  The Google Service Account to be used by Config Connector to authenticate with Google Cloud APIs. This field is used only when running in cluster mode with Workload Identity enabled.
-                  See Google Kubernetes Engine (GKE) workload-identity (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) for details. This field cannot be specified together with `credentialSecretName`.
-                  For namespaced mode, use `googleServiceAccount` in ConfigConnectorContext CRD to specify the Google Service Account to be used to authenticate with Google Cloud APIs per namespace.
+                description: The Google Service Account to be used by Config Connector
+                  to authenticate with Google Cloud APIs. This field is used only
+                  when running in cluster mode with Workload Identity enabled. See
+                  Google Kubernetes Engine (GKE) workload-identity (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
+                  for details. This field cannot be specified together with `credentialSecretName`.
+                  For namespaced mode, use `googleServiceAccount` in ConfigConnectorContext
+                  CRD to specify the Google Service Account to be used to authenticate
+                  with Google Cloud APIs per namespace.
                 type: string
               mode:
-                description: |-
-                  The mode that Config Connector will run in. This can be either 'cluster' or 'namespaced'. The default is 'namespaced'.
-                  Cluster mode uses a single Google Service Account to create and manage resources, even if you are using Config Connector to manage multiple Projects.
-                  You must specify either `credentialSecretName` or `googleServiceAccount` when in cluster mode, but not both.
-                  Namespaced mode allows you to use different Google service accounts for different Projects.
-                  When in namespaced mode, you must create a ConfigConnectorContext object per namespace that you want to enable Config Connector in, and each must set `googleServiceAccount` to specify the Google Service Account to be used to authenticate with Google Cloud APIs for the namespace.
+                description: The mode that Config Connector will run in. This can
+                  be either 'cluster' or 'namespaced'. The default is 'namespaced'.
+                  Cluster mode uses a single Google Service Account to create and
+                  manage resources, even if you are using Config Connector to manage
+                  multiple Projects. You must specify either `credentialSecretName`
+                  or `googleServiceAccount` when in cluster mode, but not both. Namespaced
+                  mode allows you to use different Google service accounts for different
+                  Projects. When in namespaced mode, you must create a ConfigConnectorContext
+                  object per namespace that you want to enable Config Connector in,
+                  and each must set `googleServiceAccount` to specify the Google Service
+                  Account to be used to authenticate with Google Cloud APIs for the
+                  namespace.
                 enum:
                 - cluster
                 - namespaced
-                type: string
-              stateIntoSpec:
-                description: |-
-                  StateIntoSpec is the user override of the default value for the
-                  'cnrm.cloud.google.com/state-into-spec' annotation if the annotation is
-                  unset for a resource.
-                  If the field is set in both the ConfigConnector object and the
-                  ConfigConnectorContext object is in the namespaced mode, then the value
-                  in the ConfigConnectorContext object will be used.
-                  'Absent' means that unspecified fields in the resource spec stay
-                  unspecified after successful reconciliation.
-                  'Merge' means that unspecified fields in the resource spec are populated
-                  after a successful reconciliation if those unspecified fields are
-                  computed/defaulted by the API. It is only applicable to resources
-                  supporting the 'Merge' option.
-                enum:
-                - Absent
-                - Merge
                 type: string
             type: object
           status:
@@ -290,8 +275,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.117.0
-    controller-gen.kubebuilder.io/version: v0.14.0
+    cnrm.cloud.google.com/operator-version: 1.116.0
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: controllerresources.customize.core.cnrm.cloud.google.com
@@ -311,19 +297,14 @@ spec:
           for config connector controllers.
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             properties:
@@ -342,22 +323,19 @@ spec:
               - containers
             - required:
               - replicas
-            description: |-
-              ControllerResourceSpec is the specification of the resource customization for containers of
-              a config connector controller.
+            description: ControllerResourceSpec is the specification of the resource
+              customization for containers of a config connector controller.
             properties:
               containers:
                 description: The list of containers whose resource requirements to
                   be customized.
                 items:
-                  description: |-
-                    ContainerResourceSpec is the specification of the resource customization for a container of
-                    a config connector controller.
+                  description: ContainerResourceSpec is the specification of the resource
+                    customization for a container of a config connector controller.
                   properties:
                     name:
-                      description: |-
-                        The name of the container whose resource requirements will be customized.
-                        Required
+                      description: The name of the container whose resource requirements
+                        will be customized. Required
                       enum:
                       - manager
                       - webhook
@@ -367,9 +345,8 @@ spec:
                       - unmanageddetector
                       type: string
                     resources:
-                      description: |-
-                        Resources specifies the resource customization of this container.
-                        Required
+                      description: Resources specifies the resource customization
+                        of this container. Required
                       properties:
                         limits:
                           additionalProperties:
@@ -378,9 +355,8 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: |-
-                            Limits describes the maximum amount of compute resources allowed.
-                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                         requests:
                           additionalProperties:
@@ -389,11 +365,11 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: |-
-                            Requests describes the minimum amount of compute resources required.
-                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests
+                            cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                       type: object
                   required:
@@ -402,9 +378,9 @@ spec:
                   type: object
                 type: array
               replicas:
-                description: |-
-                  The number of desired replicas of the config connector controller.
-                  This field takes effect only if the controller name is "cnrm-webhook-manager".
+                description: The number of desired replicas of the config connector
+                  controller. This field takes effect only if the controller name
+                  is "cnrm-webhook-manager".
                 format: int64
                 type: integer
             type: object
@@ -436,19 +412,14 @@ spec:
           for config connector controllers.
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             properties:
@@ -467,22 +438,19 @@ spec:
               - containers
             - required:
               - replicas
-            description: |-
-              ControllerResourceSpec is the specification of the resource customization for containers of
-              a config connector controller.
+            description: ControllerResourceSpec is the specification of the resource
+              customization for containers of a config connector controller.
             properties:
               containers:
                 description: The list of containers whose resource requirements to
                   be customized.
                 items:
-                  description: |-
-                    ContainerResourceSpec is the specification of the resource customization for a container of
-                    a config connector controller.
+                  description: ContainerResourceSpec is the specification of the resource
+                    customization for a container of a config connector controller.
                   properties:
                     name:
-                      description: |-
-                        The name of the container whose resource requirements will be customized.
-                        Required
+                      description: The name of the container whose resource requirements
+                        will be customized. Required
                       enum:
                       - manager
                       - webhook
@@ -492,9 +460,8 @@ spec:
                       - unmanageddetector
                       type: string
                     resources:
-                      description: |-
-                        Resources specifies the resource customization of this container.
-                        Required
+                      description: Resources specifies the resource customization
+                        of this container. Required
                       properties:
                         limits:
                           additionalProperties:
@@ -503,9 +470,8 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: |-
-                            Limits describes the maximum amount of compute resources allowed.
-                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                         requests:
                           additionalProperties:
@@ -514,11 +480,11 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: |-
-                            Requests describes the minimum amount of compute resources required.
-                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests
+                            cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                       type: object
                   required:
@@ -527,9 +493,9 @@ spec:
                   type: object
                 type: array
               replicas:
-                description: |-
-                  The number of desired replicas of the config connector controller.
-                  This field takes effect only if the controller name is "cnrm-webhook-manager".
+                description: The number of desired replicas of the config connector
+                  controller. This field takes effect only if the controller name
+                  is "cnrm-webhook-manager".
                 format: int64
                 type: integer
             type: object
@@ -559,8 +525,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.117.0
-    controller-gen.kubebuilder.io/version: v0.14.0
+    cnrm.cloud.google.com/operator-version: 1.116.0
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: mutatingwebhookconfigurationcustomizations.customize.core.cnrm.cloud.google.com
@@ -576,24 +543,18 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: |-
-          MutatingWebhookConfigurationCustomization is the Schema for customizing the mutating webhook
-          configurations in config connector.
+        description: MutatingWebhookConfigurationCustomization is the Schema for customizing
+          the mutating webhook configurations in config connector.
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             properties:
@@ -603,22 +564,19 @@ spec:
                 type: string
             type: object
           spec:
-            description: |-
-              WebhookConfigurationCustomizationSpec is the specification for customizing the webhooks of a config
-              connector webhook configuration.
+            description: WebhookConfigurationCustomizationSpec is the specification
+              for customizing the webhooks of a config connector webhook configuration.
             properties:
               webhooks:
-                description: |-
-                  The list of webhooks whose configuration to be customized.
+                description: The list of webhooks whose configuration to be customized.
                   Required
                 items:
                   description: WebhookCustomizationSpec is the specification for customizing
                     for a specific webhook in config connector.
                   properties:
                     name:
-                      description: |-
-                        The name of the webhook. Do not include the `.cnrm.cloud.google.com` suffix.
-                        Required
+                      description: The name of the webhook. Do not include the `.cnrm.cloud.google.com`
+                        suffix. Required
                       enum:
                       - abandon-on-uninstall
                       - deny-immutable-field-updates
@@ -631,11 +589,9 @@ spec:
                       - management-conflict-annotation-defaulter
                       type: string
                     timeoutSeconds:
-                      description: |-
-                        TimeoutSeconds customizes the timeout of the webhook.
-                        The timeout value must be between 1 and 30 seconds.
-                        The default timeout in Kubernetes is 10 seconds.
-                        Required
+                      description: TimeoutSeconds customizes the timeout of the webhook.
+                        The timeout value must be between 1 and 30 seconds. The default
+                        timeout in Kubernetes is 10 seconds. Required
                       format: int32
                       maximum: 30
                       minimum: 1
@@ -648,9 +604,8 @@ spec:
             - webhooks
             type: object
           status:
-            description: |-
-              WebhookConfigurationCustomizationStatus defines the observed state of ValidatingWebhookConfigurationCustomization and
-              MutatingWebhookConfigurationCustomization.
+            description: WebhookConfigurationCustomizationStatus defines the observed
+              state of ValidatingWebhookConfigurationCustomization and MutatingWebhookConfigurationCustomization.
             properties:
               errors:
                 items:
@@ -673,24 +628,18 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: |-
-          MutatingWebhookConfigurationCustomization is the Schema for customizing the mutating webhook
-          configurations in config connector.
+        description: MutatingWebhookConfigurationCustomization is the Schema for customizing
+          the mutating webhook configurations in config connector.
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             properties:
@@ -700,22 +649,19 @@ spec:
                 type: string
             type: object
           spec:
-            description: |-
-              WebhookConfigurationCustomizationSpec is the specification for customizing the webhooks of a config
-              connector webhook configuration.
+            description: WebhookConfigurationCustomizationSpec is the specification
+              for customizing the webhooks of a config connector webhook configuration.
             properties:
               webhooks:
-                description: |-
-                  The list of webhooks whose configuration to be customized.
+                description: The list of webhooks whose configuration to be customized.
                   Required
                 items:
                   description: WebhookCustomizationSpec is the specification for customizing
                     for a specific webhook in config connector.
                   properties:
                     name:
-                      description: |-
-                        The name of the webhook. Do not include the `.cnrm.cloud.google.com` suffix.
-                        Required
+                      description: The name of the webhook. Do not include the `.cnrm.cloud.google.com`
+                        suffix. Required
                       enum:
                       - abandon-on-uninstall
                       - deny-immutable-field-updates
@@ -728,11 +674,9 @@ spec:
                       - management-conflict-annotation-defaulter
                       type: string
                     timeoutSeconds:
-                      description: |-
-                        TimeoutSeconds customizes the timeout of the webhook.
-                        The timeout value must be between 1 and 30 seconds.
-                        The default timeout in Kubernetes is 10 seconds.
-                        Required
+                      description: TimeoutSeconds customizes the timeout of the webhook.
+                        The timeout value must be between 1 and 30 seconds. The default
+                        timeout in Kubernetes is 10 seconds. Required
                       format: int32
                       maximum: 30
                       minimum: 1
@@ -745,9 +689,8 @@ spec:
             - webhooks
             type: object
           status:
-            description: |-
-              WebhookConfigurationCustomizationStatus defines the observed state of ValidatingWebhookConfigurationCustomization and
-              MutatingWebhookConfigurationCustomization.
+            description: WebhookConfigurationCustomizationStatus defines the observed
+              state of ValidatingWebhookConfigurationCustomization and MutatingWebhookConfigurationCustomization.
             properties:
               errors:
                 items:
@@ -772,8 +715,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.117.0
-    controller-gen.kubebuilder.io/version: v0.14.0
+    cnrm.cloud.google.com/operator-version: 1.116.0
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: namespacedcontrollerresources.customize.core.cnrm.cloud.google.com
@@ -793,19 +737,14 @@ spec:
           API for namespaced config connector controllers.
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             properties:
@@ -815,23 +754,20 @@ spec:
                 type: string
             type: object
           spec:
-            description: |-
-              NamespacedControllerResourceSpec is the specification of the resource customization for containers of
-              a namespaced config connector controller.
+            description: NamespacedControllerResourceSpec is the specification of
+              the resource customization for containers of a namespaced config connector
+              controller.
             properties:
               containers:
-                description: |-
-                  The list of containers whose resource requirements to be customized.
-                  Required
+                description: The list of containers whose resource requirements to
+                  be customized. Required
                 items:
-                  description: |-
-                    ContainerResourceSpec is the specification of the resource customization for a container of
-                    a config connector controller.
+                  description: ContainerResourceSpec is the specification of the resource
+                    customization for a container of a config connector controller.
                   properties:
                     name:
-                      description: |-
-                        The name of the container whose resource requirements will be customized.
-                        Required
+                      description: The name of the container whose resource requirements
+                        will be customized. Required
                       enum:
                       - manager
                       - webhook
@@ -841,9 +777,8 @@ spec:
                       - unmanageddetector
                       type: string
                     resources:
-                      description: |-
-                        Resources specifies the resource customization of this container.
-                        Required
+                      description: Resources specifies the resource customization
+                        of this container. Required
                       properties:
                         limits:
                           additionalProperties:
@@ -852,9 +787,8 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: |-
-                            Limits describes the maximum amount of compute resources allowed.
-                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                         requests:
                           additionalProperties:
@@ -863,11 +797,11 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: |-
-                            Requests describes the minimum amount of compute resources required.
-                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests
+                            cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                       type: object
                   required:
@@ -907,19 +841,14 @@ spec:
           API for namespaced config connector controllers.
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             properties:
@@ -929,23 +858,20 @@ spec:
                 type: string
             type: object
           spec:
-            description: |-
-              NamespacedControllerResourceSpec is the specification of the resource customization for containers of
-              a namespaced config connector controller.
+            description: NamespacedControllerResourceSpec is the specification of
+              the resource customization for containers of a namespaced config connector
+              controller.
             properties:
               containers:
-                description: |-
-                  The list of containers whose resource requirements to be customized.
-                  Required
+                description: The list of containers whose resource requirements to
+                  be customized. Required
                 items:
-                  description: |-
-                    ContainerResourceSpec is the specification of the resource customization for a container of
-                    a config connector controller.
+                  description: ContainerResourceSpec is the specification of the resource
+                    customization for a container of a config connector controller.
                   properties:
                     name:
-                      description: |-
-                        The name of the container whose resource requirements will be customized.
-                        Required
+                      description: The name of the container whose resource requirements
+                        will be customized. Required
                       enum:
                       - manager
                       - webhook
@@ -955,9 +881,8 @@ spec:
                       - unmanageddetector
                       type: string
                     resources:
-                      description: |-
-                        Resources specifies the resource customization of this container.
-                        Required
+                      description: Resources specifies the resource customization
+                        of this container. Required
                       properties:
                         limits:
                           additionalProperties:
@@ -966,9 +891,8 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: |-
-                            Limits describes the maximum amount of compute resources allowed.
-                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                         requests:
                           additionalProperties:
@@ -977,11 +901,11 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: |-
-                            Requests describes the minimum amount of compute resources required.
-                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests
+                            cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                       type: object
                   required:
@@ -1019,8 +943,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.117.0
-    controller-gen.kubebuilder.io/version: v0.14.0
+    cnrm.cloud.google.com/operator-version: 1.116.0
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: validatingwebhookconfigurationcustomizations.customize.core.cnrm.cloud.google.com
@@ -1036,24 +961,18 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: |-
-          ValidatingWebhookConfigurationCustomization is the Schema for customizing the validating webhook
-          configurations in config connector.
+        description: ValidatingWebhookConfigurationCustomization is the Schema for
+          customizing the validating webhook configurations in config connector.
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             properties:
@@ -1064,22 +983,19 @@ spec:
                 type: string
             type: object
           spec:
-            description: |-
-              WebhookConfigurationCustomizationSpec is the specification for customizing the webhooks of a config
-              connector webhook configuration.
+            description: WebhookConfigurationCustomizationSpec is the specification
+              for customizing the webhooks of a config connector webhook configuration.
             properties:
               webhooks:
-                description: |-
-                  The list of webhooks whose configuration to be customized.
+                description: The list of webhooks whose configuration to be customized.
                   Required
                 items:
                   description: WebhookCustomizationSpec is the specification for customizing
                     for a specific webhook in config connector.
                   properties:
                     name:
-                      description: |-
-                        The name of the webhook. Do not include the `.cnrm.cloud.google.com` suffix.
-                        Required
+                      description: The name of the webhook. Do not include the `.cnrm.cloud.google.com`
+                        suffix. Required
                       enum:
                       - abandon-on-uninstall
                       - deny-immutable-field-updates
@@ -1092,11 +1008,9 @@ spec:
                       - management-conflict-annotation-defaulter
                       type: string
                     timeoutSeconds:
-                      description: |-
-                        TimeoutSeconds customizes the timeout of the webhook.
-                        The timeout value must be between 1 and 30 seconds.
-                        The default timeout in Kubernetes is 10 seconds.
-                        Required
+                      description: TimeoutSeconds customizes the timeout of the webhook.
+                        The timeout value must be between 1 and 30 seconds. The default
+                        timeout in Kubernetes is 10 seconds. Required
                       format: int32
                       maximum: 30
                       minimum: 1
@@ -1109,9 +1023,8 @@ spec:
             - webhooks
             type: object
           status:
-            description: |-
-              WebhookConfigurationCustomizationStatus defines the observed state of ValidatingWebhookConfigurationCustomization and
-              MutatingWebhookConfigurationCustomization.
+            description: WebhookConfigurationCustomizationStatus defines the observed
+              state of ValidatingWebhookConfigurationCustomization and MutatingWebhookConfigurationCustomization.
             properties:
               errors:
                 items:
@@ -1134,24 +1047,18 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: |-
-          ValidatingWebhookConfigurationCustomization is the Schema for customizing the validating webhook
-          configurations in config connector.
+        description: ValidatingWebhookConfigurationCustomization is the Schema for
+          customizing the validating webhook configurations in config connector.
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             properties:
@@ -1162,22 +1069,19 @@ spec:
                 type: string
             type: object
           spec:
-            description: |-
-              WebhookConfigurationCustomizationSpec is the specification for customizing the webhooks of a config
-              connector webhook configuration.
+            description: WebhookConfigurationCustomizationSpec is the specification
+              for customizing the webhooks of a config connector webhook configuration.
             properties:
               webhooks:
-                description: |-
-                  The list of webhooks whose configuration to be customized.
+                description: The list of webhooks whose configuration to be customized.
                   Required
                 items:
                   description: WebhookCustomizationSpec is the specification for customizing
                     for a specific webhook in config connector.
                   properties:
                     name:
-                      description: |-
-                        The name of the webhook. Do not include the `.cnrm.cloud.google.com` suffix.
-                        Required
+                      description: The name of the webhook. Do not include the `.cnrm.cloud.google.com`
+                        suffix. Required
                       enum:
                       - abandon-on-uninstall
                       - deny-immutable-field-updates
@@ -1190,11 +1094,9 @@ spec:
                       - management-conflict-annotation-defaulter
                       type: string
                     timeoutSeconds:
-                      description: |-
-                        TimeoutSeconds customizes the timeout of the webhook.
-                        The timeout value must be between 1 and 30 seconds.
-                        The default timeout in Kubernetes is 10 seconds.
-                        Required
+                      description: TimeoutSeconds customizes the timeout of the webhook.
+                        The timeout value must be between 1 and 30 seconds. The default
+                        timeout in Kubernetes is 10 seconds. Required
                       format: int32
                       maximum: 30
                       minimum: 1
@@ -1207,9 +1109,8 @@ spec:
             - webhooks
             type: object
           status:
-            description: |-
-              WebhookConfigurationCustomizationStatus defines the observed state of ValidatingWebhookConfigurationCustomization and
-              MutatingWebhookConfigurationCustomization.
+            description: WebhookConfigurationCustomizationStatus defines the observed
+              state of ValidatingWebhookConfigurationCustomization and MutatingWebhookConfigurationCustomization.
             properties:
               errors:
                 items:
@@ -1234,7 +1135,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.117.0
+    cnrm.cloud.google.com/operator-version: 1.116.0
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: configconnector-operator
@@ -1244,8 +1145,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.117.0
-    cnrm.cloud.google.com/version: 1.117.0
+    cnrm.cloud.google.com/operator-version: 1.116.0
+    cnrm.cloud.google.com/version: 1.116.0
   creationTimestamp: null
   labels:
     cnrm.cloud.google.com/operator-system: "true"
@@ -2034,7 +1935,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.117.0
+    cnrm.cloud.google.com/operator-version: 1.116.0
   creationTimestamp: null
   labels:
     cnrm.cloud.google.com/operator-system: "true"
@@ -2226,7 +2127,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.117.0
+    cnrm.cloud.google.com/operator-version: 1.116.0
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: configconnector-operator-cnrm-viewer-role-binding
@@ -2243,7 +2144,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.117.0
+    cnrm.cloud.google.com/operator-version: 1.116.0
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: configconnector-operator-rolebinding
@@ -2260,7 +2161,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.117.0
+    cnrm.cloud.google.com/operator-version: 1.116.0
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: configconnector-operator-service
@@ -2277,7 +2178,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.117.0
+    cnrm.cloud.google.com/operator-version: 1.116.0
   labels:
     cnrm.cloud.google.com/component: configconnector-operator
     cnrm.cloud.google.com/operator-system: "true"
@@ -2293,7 +2194,7 @@ spec:
   template:
     metadata:
       annotations:
-        cnrm.cloud.google.com/operator-version: 1.117.0
+        cnrm.cloud.google.com/operator-version: 1.116.0
       labels:
         cnrm.cloud.google.com/component: configconnector-operator
         cnrm.cloud.google.com/operator-system: "true"
@@ -2303,7 +2204,7 @@ spec:
         - --local-repo=/configconnector-operator/autopilot-channels
         command:
         - /configconnector-operator/manager
-        image: gcr.io/gke-release/cnrm/operator:d7eac56
+        image: gcr.io/gke-release/cnrm/operator:010d66d
         imagePullPolicy: Always
         name: manager
         resources:

--- a/k8s/configconnector-operator-system/autopilot-configconnector-operator.yaml
+++ b/k8s/configconnector-operator-system/autopilot-configconnector-operator.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.113.0
+    cnrm.cloud.google.com/operator-version: 1.117.0
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: configconnector-operator-system
@@ -11,9 +11,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.113.0
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    cnrm.cloud.google.com/operator-version: 1.117.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: configconnectorcontexts.core.cnrm.cloud.google.com
@@ -42,42 +41,72 @@ spec:
           API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
             description: ConfigConnectorContextSpec defines the desired state of ConfigConnectorContext
             properties:
+              actuationMode:
+                description: |-
+                  The actuation mode of Config Connector controls how resources are actuated onto the cloud provider.
+                  This can be either 'Reconciling' or 'Paused'. The default is 'Reconciling' where resources get actuated.
+                  In 'Paused', k8s resources are still reconciled with the api server but not actuated onto the cloud provider.
+                enum:
+                - Reconciling
+                - Paused
+                type: string
               billingProject:
-                description: Specifies the project to use for preconditions, quota
-                  and billing. Should only be used when requestProjectPolicy is set
-                  to BILLING_PROJECT.
+                description: |-
+                  Specifies the project to use for preconditions, quota and billing.
+                  Should only be used when requestProjectPolicy is set to BILLING_PROJECT.
                 type: string
               googleServiceAccount:
-                description: The Google Service Account to be used by Config Connector
-                  to authenticate with Google Cloud APIs in the associated namespace.
+                description: |-
+                  The Google Service Account to be used by Config Connector to
+                  authenticate with Google Cloud APIs in the associated namespace.
                 type: string
               requestProjectPolicy:
-                description: Specifies which project to use for preconditions, quota,
-                  and billing for requests made to Google Cloud APIs for resources
-                  in the associated namespace. Must be one of 'SERVICE_ACCOUNT_PROJECT',
-                  'RESOURCE_PROJECT', or 'BILLING_PROJECT. Defaults to 'SERVICE_ACCOUNT_PROJECT'.
-                  If set to 'SERVICE_ACCOUNT_PROJECT', uses the project that the Google
-                  Service Account belongs to. If set to 'RESOURCE_PROJECT', uses the
-                  project that the resource belongs to. If set to 'BILLING_PROJECT',
-                  uses the project specified by spec.billingProject.
+                description: |-
+                  Specifies which project to use for preconditions, quota, and billing for
+                  requests made to Google Cloud APIs for resources in the associated
+                  namespace. Must be one of 'SERVICE_ACCOUNT_PROJECT',
+                  'RESOURCE_PROJECT', or 'BILLING_PROJECT. Defaults to 'SERVICE_ACCOUNT_PROJECT'. If set to
+                  'SERVICE_ACCOUNT_PROJECT', uses the project that the Google Service
+                  Account belongs to. If set to 'RESOURCE_PROJECT', uses the project that
+                  the resource belongs to. If set to 'BILLING_PROJECT', uses the project specified by spec.billingProject.
                 enum:
                 - SERVICE_ACCOUNT_PROJECT
                 - RESOURCE_PROJECT
                 - BILLING_PROJECT
+                type: string
+              stateIntoSpec:
+                description: |-
+                  StateIntoSpec is the user override of the default value for the
+                  'cnrm.cloud.google.com/state-into-spec' annotation if the annotation is
+                  unset for a resource.
+                  'Absent' means that unspecified fields in the resource spec stay
+                  unspecified after successful reconciliation.
+                  'Merge' means that unspecified fields in the resource spec are populated
+                  after a successful reconciliation if those unspecified fields are
+                  computed/defaulted by the API. It is only applicable to resources
+                  supporting the 'Merge' option.
+                enum:
+                - Absent
+                - Merge
                 type: string
             required:
             - googleServiceAccount
@@ -109,9 +138,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.113.0
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    cnrm.cloud.google.com/operator-version: 1.117.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: configconnectors.core.cnrm.cloud.google.com
@@ -139,14 +167,19 @@ spec:
         description: ConfigConnector is the Schema for the configconnectors API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -179,41 +212,58 @@ spec:
                   - namespaced
             description: ConfigConnectorSpec defines the desired state of ConfigConnector
             properties:
+              actuationMode:
+                description: |-
+                  The actuation mode of Config Connector controls how resources are actuated onto the cloud provider.
+                  This can be either 'Reconciling' or 'Paused'.
+                  In 'Paused', k8s resources are still reconciled with the api server but not actuated onto the cloud provider.
+                  If Config Connector is running in 'namespaced' mode, then the value in ConfigConnectorContext (CCC) takes precedence.
+                  If CCC doesn't define a value but ConfigConnecor (CC) does, we defer to that value. Otherwise,
+                  the default is 'Reconciling' where resources get actuated.
+                enum:
+                - Reconciling
+                - Paused
+                type: string
               credentialSecretName:
-                description: The Kubernetes secret that contains the Google Service
-                  Account Key's credentials to be used by ConfigConnector to authenticate
-                  with Google Cloud APIs. This field is used only when in cluster
-                  mode. It's recommended to use `googleServiceAccount` when running
-                  ConfigConnector in Google Kubernetes Engine (GKE) clusters with
-                  Workload Identity enabled. This field cannot be specified together
-                  with `googleServiceAccount`.
+                description: |-
+                  The Kubernetes secret that contains the Google Service Account Key's credentials to be used by ConfigConnector to authenticate with Google Cloud APIs. This field is used only when in cluster mode.
+                  It's recommended to use `googleServiceAccount` when running ConfigConnector in Google Kubernetes Engine (GKE) clusters with Workload Identity enabled.
+                  This field cannot be specified together with `googleServiceAccount`.
                 type: string
               googleServiceAccount:
-                description: The Google Service Account to be used by Config Connector
-                  to authenticate with Google Cloud APIs. This field is used only
-                  when running in cluster mode with Workload Identity enabled. See
-                  Google Kubernetes Engine (GKE) workload-identity (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
-                  for details. This field cannot be specified together with `credentialSecretName`.
-                  For namespaced mode, use `googleServiceAccount` in ConfigConnectorContext
-                  CRD to specify the Google Service Account to be used to authenticate
-                  with Google Cloud APIs per namespace.
+                description: |-
+                  The Google Service Account to be used by Config Connector to authenticate with Google Cloud APIs. This field is used only when running in cluster mode with Workload Identity enabled.
+                  See Google Kubernetes Engine (GKE) workload-identity (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) for details. This field cannot be specified together with `credentialSecretName`.
+                  For namespaced mode, use `googleServiceAccount` in ConfigConnectorContext CRD to specify the Google Service Account to be used to authenticate with Google Cloud APIs per namespace.
                 type: string
               mode:
-                description: The mode that Config Connector will run in. This can
-                  be either 'cluster' or 'namespaced'. The default is 'namespaced'.
-                  Cluster mode uses a single Google Service Account to create and
-                  manage resources, even if you are using Config Connector to manage
-                  multiple Projects. You must specify either `credentialSecretName`
-                  or `googleServiceAccount` when in cluster mode, but not both. Namespaced
-                  mode allows you to use different Google service accounts for different
-                  Projects. When in namespaced mode, you must create a ConfigConnectorContext
-                  object per namespace that you want to enable Config Connector in,
-                  and each must set `googleServiceAccount` to specify the Google Service
-                  Account to be used to authenticate with Google Cloud APIs for the
-                  namespace.
+                description: |-
+                  The mode that Config Connector will run in. This can be either 'cluster' or 'namespaced'. The default is 'namespaced'.
+                  Cluster mode uses a single Google Service Account to create and manage resources, even if you are using Config Connector to manage multiple Projects.
+                  You must specify either `credentialSecretName` or `googleServiceAccount` when in cluster mode, but not both.
+                  Namespaced mode allows you to use different Google service accounts for different Projects.
+                  When in namespaced mode, you must create a ConfigConnectorContext object per namespace that you want to enable Config Connector in, and each must set `googleServiceAccount` to specify the Google Service Account to be used to authenticate with Google Cloud APIs for the namespace.
                 enum:
                 - cluster
                 - namespaced
+                type: string
+              stateIntoSpec:
+                description: |-
+                  StateIntoSpec is the user override of the default value for the
+                  'cnrm.cloud.google.com/state-into-spec' annotation if the annotation is
+                  unset for a resource.
+                  If the field is set in both the ConfigConnector object and the
+                  ConfigConnectorContext object is in the namespaced mode, then the value
+                  in the ConfigConnectorContext object will be used.
+                  'Absent' means that unspecified fields in the resource spec stay
+                  unspecified after successful reconciliation.
+                  'Merge' means that unspecified fields in the resource spec are populated
+                  after a successful reconciliation if those unspecified fields are
+                  computed/defaulted by the API. It is only applicable to resources
+                  supporting the 'Merge' option.
+                enum:
+                - Absent
+                - Merge
                 type: string
             type: object
           status:
@@ -240,9 +290,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.113.0
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    cnrm.cloud.google.com/operator-version: 1.117.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: controllerresources.customize.core.cnrm.cloud.google.com
@@ -262,14 +311,19 @@ spec:
           for config connector controllers.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             properties:
@@ -288,19 +342,22 @@ spec:
               - containers
             - required:
               - replicas
-            description: ControllerResourceSpec is the specification of the resource
-              customization for containers of a config connector controller.
+            description: |-
+              ControllerResourceSpec is the specification of the resource customization for containers of
+              a config connector controller.
             properties:
               containers:
                 description: The list of containers whose resource requirements to
                   be customized.
                 items:
-                  description: ContainerResourceSpec is the specification of the resource
-                    customization for a container of a config connector controller.
+                  description: |-
+                    ContainerResourceSpec is the specification of the resource customization for a container of
+                    a config connector controller.
                   properties:
                     name:
-                      description: The name of the container whose resource requirements
-                        will be customized. Required
+                      description: |-
+                        The name of the container whose resource requirements will be customized.
+                        Required
                       enum:
                       - manager
                       - webhook
@@ -310,8 +367,9 @@ spec:
                       - unmanageddetector
                       type: string
                     resources:
-                      description: Resources specifies the resource customization
-                        of this container. Required
+                      description: |-
+                        Resources specifies the resource customization of this container.
+                        Required
                       properties:
                         limits:
                           additionalProperties:
@@ -320,8 +378,9 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                           type: object
                         requests:
                           additionalProperties:
@@ -330,11 +389,11 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. Requests
-                            cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                           type: object
                       type: object
                   required:
@@ -343,9 +402,9 @@ spec:
                   type: object
                 type: array
               replicas:
-                description: The number of desired replicas of the config connector
-                  controller. This field takes effect only if the controller name
-                  is "cnrm-webhook-manager".
+                description: |-
+                  The number of desired replicas of the config connector controller.
+                  This field takes effect only if the controller name is "cnrm-webhook-manager".
                 format: int64
                 type: integer
             type: object
@@ -377,14 +436,19 @@ spec:
           for config connector controllers.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             properties:
@@ -403,19 +467,22 @@ spec:
               - containers
             - required:
               - replicas
-            description: ControllerResourceSpec is the specification of the resource
-              customization for containers of a config connector controller.
+            description: |-
+              ControllerResourceSpec is the specification of the resource customization for containers of
+              a config connector controller.
             properties:
               containers:
                 description: The list of containers whose resource requirements to
                   be customized.
                 items:
-                  description: ContainerResourceSpec is the specification of the resource
-                    customization for a container of a config connector controller.
+                  description: |-
+                    ContainerResourceSpec is the specification of the resource customization for a container of
+                    a config connector controller.
                   properties:
                     name:
-                      description: The name of the container whose resource requirements
-                        will be customized. Required
+                      description: |-
+                        The name of the container whose resource requirements will be customized.
+                        Required
                       enum:
                       - manager
                       - webhook
@@ -425,8 +492,9 @@ spec:
                       - unmanageddetector
                       type: string
                     resources:
-                      description: Resources specifies the resource customization
-                        of this container. Required
+                      description: |-
+                        Resources specifies the resource customization of this container.
+                        Required
                       properties:
                         limits:
                           additionalProperties:
@@ -435,8 +503,9 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                           type: object
                         requests:
                           additionalProperties:
@@ -445,11 +514,11 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. Requests
-                            cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                           type: object
                       type: object
                   required:
@@ -458,9 +527,9 @@ spec:
                   type: object
                 type: array
               replicas:
-                description: The number of desired replicas of the config connector
-                  controller. This field takes effect only if the controller name
-                  is "cnrm-webhook-manager".
+                description: |-
+                  The number of desired replicas of the config connector controller.
+                  This field takes effect only if the controller name is "cnrm-webhook-manager".
                 format: int64
                 type: integer
             type: object
@@ -490,9 +559,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.113.0
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    cnrm.cloud.google.com/operator-version: 1.117.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: mutatingwebhookconfigurationcustomizations.customize.core.cnrm.cloud.google.com
@@ -508,18 +576,24 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: MutatingWebhookConfigurationCustomization is the Schema for customizing
-          the mutating webhook configurations in config connector.
+        description: |-
+          MutatingWebhookConfigurationCustomization is the Schema for customizing the mutating webhook
+          configurations in config connector.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             properties:
@@ -529,19 +603,22 @@ spec:
                 type: string
             type: object
           spec:
-            description: WebhookConfigurationCustomizationSpec is the specification
-              for customizing the webhooks of a config connector webhook configuration.
+            description: |-
+              WebhookConfigurationCustomizationSpec is the specification for customizing the webhooks of a config
+              connector webhook configuration.
             properties:
               webhooks:
-                description: The list of webhooks whose configuration to be customized.
+                description: |-
+                  The list of webhooks whose configuration to be customized.
                   Required
                 items:
                   description: WebhookCustomizationSpec is the specification for customizing
                     for a specific webhook in config connector.
                   properties:
                     name:
-                      description: The name of the webhook. Do not include the `.cnrm.cloud.google.com`
-                        suffix. Required
+                      description: |-
+                        The name of the webhook. Do not include the `.cnrm.cloud.google.com` suffix.
+                        Required
                       enum:
                       - abandon-on-uninstall
                       - deny-immutable-field-updates
@@ -554,9 +631,11 @@ spec:
                       - management-conflict-annotation-defaulter
                       type: string
                     timeoutSeconds:
-                      description: TimeoutSeconds customizes the timeout of the webhook.
-                        The timeout value must be between 1 and 30 seconds. The default
-                        timeout in Kubernetes is 10 seconds. Required
+                      description: |-
+                        TimeoutSeconds customizes the timeout of the webhook.
+                        The timeout value must be between 1 and 30 seconds.
+                        The default timeout in Kubernetes is 10 seconds.
+                        Required
                       format: int32
                       maximum: 30
                       minimum: 1
@@ -569,8 +648,9 @@ spec:
             - webhooks
             type: object
           status:
-            description: WebhookConfigurationCustomizationStatus defines the observed
-              state of ValidatingWebhookConfigurationCustomization and MutatingWebhookConfigurationCustomization.
+            description: |-
+              WebhookConfigurationCustomizationStatus defines the observed state of ValidatingWebhookConfigurationCustomization and
+              MutatingWebhookConfigurationCustomization.
             properties:
               errors:
                 items:
@@ -593,18 +673,24 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: MutatingWebhookConfigurationCustomization is the Schema for customizing
-          the mutating webhook configurations in config connector.
+        description: |-
+          MutatingWebhookConfigurationCustomization is the Schema for customizing the mutating webhook
+          configurations in config connector.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             properties:
@@ -614,19 +700,22 @@ spec:
                 type: string
             type: object
           spec:
-            description: WebhookConfigurationCustomizationSpec is the specification
-              for customizing the webhooks of a config connector webhook configuration.
+            description: |-
+              WebhookConfigurationCustomizationSpec is the specification for customizing the webhooks of a config
+              connector webhook configuration.
             properties:
               webhooks:
-                description: The list of webhooks whose configuration to be customized.
+                description: |-
+                  The list of webhooks whose configuration to be customized.
                   Required
                 items:
                   description: WebhookCustomizationSpec is the specification for customizing
                     for a specific webhook in config connector.
                   properties:
                     name:
-                      description: The name of the webhook. Do not include the `.cnrm.cloud.google.com`
-                        suffix. Required
+                      description: |-
+                        The name of the webhook. Do not include the `.cnrm.cloud.google.com` suffix.
+                        Required
                       enum:
                       - abandon-on-uninstall
                       - deny-immutable-field-updates
@@ -639,9 +728,11 @@ spec:
                       - management-conflict-annotation-defaulter
                       type: string
                     timeoutSeconds:
-                      description: TimeoutSeconds customizes the timeout of the webhook.
-                        The timeout value must be between 1 and 30 seconds. The default
-                        timeout in Kubernetes is 10 seconds. Required
+                      description: |-
+                        TimeoutSeconds customizes the timeout of the webhook.
+                        The timeout value must be between 1 and 30 seconds.
+                        The default timeout in Kubernetes is 10 seconds.
+                        Required
                       format: int32
                       maximum: 30
                       minimum: 1
@@ -654,8 +745,9 @@ spec:
             - webhooks
             type: object
           status:
-            description: WebhookConfigurationCustomizationStatus defines the observed
-              state of ValidatingWebhookConfigurationCustomization and MutatingWebhookConfigurationCustomization.
+            description: |-
+              WebhookConfigurationCustomizationStatus defines the observed state of ValidatingWebhookConfigurationCustomization and
+              MutatingWebhookConfigurationCustomization.
             properties:
               errors:
                 items:
@@ -680,9 +772,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.113.0
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    cnrm.cloud.google.com/operator-version: 1.117.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: namespacedcontrollerresources.customize.core.cnrm.cloud.google.com
@@ -702,14 +793,19 @@ spec:
           API for namespaced config connector controllers.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             properties:
@@ -719,20 +815,23 @@ spec:
                 type: string
             type: object
           spec:
-            description: NamespacedControllerResourceSpec is the specification of
-              the resource customization for containers of a namespaced config connector
-              controller.
+            description: |-
+              NamespacedControllerResourceSpec is the specification of the resource customization for containers of
+              a namespaced config connector controller.
             properties:
               containers:
-                description: The list of containers whose resource requirements to
-                  be customized. Required
+                description: |-
+                  The list of containers whose resource requirements to be customized.
+                  Required
                 items:
-                  description: ContainerResourceSpec is the specification of the resource
-                    customization for a container of a config connector controller.
+                  description: |-
+                    ContainerResourceSpec is the specification of the resource customization for a container of
+                    a config connector controller.
                   properties:
                     name:
-                      description: The name of the container whose resource requirements
-                        will be customized. Required
+                      description: |-
+                        The name of the container whose resource requirements will be customized.
+                        Required
                       enum:
                       - manager
                       - webhook
@@ -742,8 +841,9 @@ spec:
                       - unmanageddetector
                       type: string
                     resources:
-                      description: Resources specifies the resource customization
-                        of this container. Required
+                      description: |-
+                        Resources specifies the resource customization of this container.
+                        Required
                       properties:
                         limits:
                           additionalProperties:
@@ -752,8 +852,9 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                           type: object
                         requests:
                           additionalProperties:
@@ -762,11 +863,11 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. Requests
-                            cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                           type: object
                       type: object
                   required:
@@ -806,14 +907,19 @@ spec:
           API for namespaced config connector controllers.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             properties:
@@ -823,20 +929,23 @@ spec:
                 type: string
             type: object
           spec:
-            description: NamespacedControllerResourceSpec is the specification of
-              the resource customization for containers of a namespaced config connector
-              controller.
+            description: |-
+              NamespacedControllerResourceSpec is the specification of the resource customization for containers of
+              a namespaced config connector controller.
             properties:
               containers:
-                description: The list of containers whose resource requirements to
-                  be customized. Required
+                description: |-
+                  The list of containers whose resource requirements to be customized.
+                  Required
                 items:
-                  description: ContainerResourceSpec is the specification of the resource
-                    customization for a container of a config connector controller.
+                  description: |-
+                    ContainerResourceSpec is the specification of the resource customization for a container of
+                    a config connector controller.
                   properties:
                     name:
-                      description: The name of the container whose resource requirements
-                        will be customized. Required
+                      description: |-
+                        The name of the container whose resource requirements will be customized.
+                        Required
                       enum:
                       - manager
                       - webhook
@@ -846,8 +955,9 @@ spec:
                       - unmanageddetector
                       type: string
                     resources:
-                      description: Resources specifies the resource customization
-                        of this container. Required
+                      description: |-
+                        Resources specifies the resource customization of this container.
+                        Required
                       properties:
                         limits:
                           additionalProperties:
@@ -856,8 +966,9 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                           type: object
                         requests:
                           additionalProperties:
@@ -866,11 +977,11 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. Requests
-                            cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                           type: object
                       type: object
                   required:
@@ -908,9 +1019,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.113.0
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    cnrm.cloud.google.com/operator-version: 1.117.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: validatingwebhookconfigurationcustomizations.customize.core.cnrm.cloud.google.com
@@ -926,18 +1036,24 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ValidatingWebhookConfigurationCustomization is the Schema for
-          customizing the validating webhook configurations in config connector.
+        description: |-
+          ValidatingWebhookConfigurationCustomization is the Schema for customizing the validating webhook
+          configurations in config connector.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             properties:
@@ -948,19 +1064,22 @@ spec:
                 type: string
             type: object
           spec:
-            description: WebhookConfigurationCustomizationSpec is the specification
-              for customizing the webhooks of a config connector webhook configuration.
+            description: |-
+              WebhookConfigurationCustomizationSpec is the specification for customizing the webhooks of a config
+              connector webhook configuration.
             properties:
               webhooks:
-                description: The list of webhooks whose configuration to be customized.
+                description: |-
+                  The list of webhooks whose configuration to be customized.
                   Required
                 items:
                   description: WebhookCustomizationSpec is the specification for customizing
                     for a specific webhook in config connector.
                   properties:
                     name:
-                      description: The name of the webhook. Do not include the `.cnrm.cloud.google.com`
-                        suffix. Required
+                      description: |-
+                        The name of the webhook. Do not include the `.cnrm.cloud.google.com` suffix.
+                        Required
                       enum:
                       - abandon-on-uninstall
                       - deny-immutable-field-updates
@@ -973,9 +1092,11 @@ spec:
                       - management-conflict-annotation-defaulter
                       type: string
                     timeoutSeconds:
-                      description: TimeoutSeconds customizes the timeout of the webhook.
-                        The timeout value must be between 1 and 30 seconds. The default
-                        timeout in Kubernetes is 10 seconds. Required
+                      description: |-
+                        TimeoutSeconds customizes the timeout of the webhook.
+                        The timeout value must be between 1 and 30 seconds.
+                        The default timeout in Kubernetes is 10 seconds.
+                        Required
                       format: int32
                       maximum: 30
                       minimum: 1
@@ -988,8 +1109,9 @@ spec:
             - webhooks
             type: object
           status:
-            description: WebhookConfigurationCustomizationStatus defines the observed
-              state of ValidatingWebhookConfigurationCustomization and MutatingWebhookConfigurationCustomization.
+            description: |-
+              WebhookConfigurationCustomizationStatus defines the observed state of ValidatingWebhookConfigurationCustomization and
+              MutatingWebhookConfigurationCustomization.
             properties:
               errors:
                 items:
@@ -1012,18 +1134,24 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: ValidatingWebhookConfigurationCustomization is the Schema for
-          customizing the validating webhook configurations in config connector.
+        description: |-
+          ValidatingWebhookConfigurationCustomization is the Schema for customizing the validating webhook
+          configurations in config connector.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             properties:
@@ -1034,19 +1162,22 @@ spec:
                 type: string
             type: object
           spec:
-            description: WebhookConfigurationCustomizationSpec is the specification
-              for customizing the webhooks of a config connector webhook configuration.
+            description: |-
+              WebhookConfigurationCustomizationSpec is the specification for customizing the webhooks of a config
+              connector webhook configuration.
             properties:
               webhooks:
-                description: The list of webhooks whose configuration to be customized.
+                description: |-
+                  The list of webhooks whose configuration to be customized.
                   Required
                 items:
                   description: WebhookCustomizationSpec is the specification for customizing
                     for a specific webhook in config connector.
                   properties:
                     name:
-                      description: The name of the webhook. Do not include the `.cnrm.cloud.google.com`
-                        suffix. Required
+                      description: |-
+                        The name of the webhook. Do not include the `.cnrm.cloud.google.com` suffix.
+                        Required
                       enum:
                       - abandon-on-uninstall
                       - deny-immutable-field-updates
@@ -1059,9 +1190,11 @@ spec:
                       - management-conflict-annotation-defaulter
                       type: string
                     timeoutSeconds:
-                      description: TimeoutSeconds customizes the timeout of the webhook.
-                        The timeout value must be between 1 and 30 seconds. The default
-                        timeout in Kubernetes is 10 seconds. Required
+                      description: |-
+                        TimeoutSeconds customizes the timeout of the webhook.
+                        The timeout value must be between 1 and 30 seconds.
+                        The default timeout in Kubernetes is 10 seconds.
+                        Required
                       format: int32
                       maximum: 30
                       minimum: 1
@@ -1074,8 +1207,9 @@ spec:
             - webhooks
             type: object
           status:
-            description: WebhookConfigurationCustomizationStatus defines the observed
-              state of ValidatingWebhookConfigurationCustomization and MutatingWebhookConfigurationCustomization.
+            description: |-
+              WebhookConfigurationCustomizationStatus defines the observed state of ValidatingWebhookConfigurationCustomization and
+              MutatingWebhookConfigurationCustomization.
             properties:
               errors:
                 items:
@@ -1100,7 +1234,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.113.0
+    cnrm.cloud.google.com/operator-version: 1.117.0
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: configconnector-operator
@@ -1110,8 +1244,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.113.0
-    cnrm.cloud.google.com/version: 1.113.0
+    cnrm.cloud.google.com/operator-version: 1.117.0
+    cnrm.cloud.google.com/version: 1.117.0
   creationTimestamp: null
   labels:
     cnrm.cloud.google.com/operator-system: "true"
@@ -1145,6 +1279,14 @@ rules:
   - watch
 - apiGroups:
   - apigee.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apikeys.cnrm.cloud.google.com
   resources:
   - '*'
   verbs:
@@ -1892,7 +2034,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.113.0
+    cnrm.cloud.google.com/operator-version: 1.117.0
   creationTimestamp: null
   labels:
     cnrm.cloud.google.com/operator-system: "true"
@@ -2084,7 +2226,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.113.0
+    cnrm.cloud.google.com/operator-version: 1.117.0
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: configconnector-operator-cnrm-viewer-role-binding
@@ -2101,7 +2243,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.113.0
+    cnrm.cloud.google.com/operator-version: 1.117.0
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: configconnector-operator-rolebinding
@@ -2118,7 +2260,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.113.0
+    cnrm.cloud.google.com/operator-version: 1.117.0
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: configconnector-operator-service
@@ -2135,7 +2277,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.113.0
+    cnrm.cloud.google.com/operator-version: 1.117.0
   labels:
     cnrm.cloud.google.com/component: configconnector-operator
     cnrm.cloud.google.com/operator-system: "true"
@@ -2151,7 +2293,7 @@ spec:
   template:
     metadata:
       annotations:
-        cnrm.cloud.google.com/operator-version: 1.113.0
+        cnrm.cloud.google.com/operator-version: 1.117.0
       labels:
         cnrm.cloud.google.com/component: configconnector-operator
         cnrm.cloud.google.com/operator-system: "true"
@@ -2161,7 +2303,7 @@ spec:
         - --local-repo=/configconnector-operator/autopilot-channels
         command:
         - /configconnector-operator/manager
-        image: gcr.io/gke-release/cnrm/operator:2d9421c
+        image: gcr.io/gke-release/cnrm/operator:d7eac56
         imagePullPolicy: Always
         name: manager
         resources:


### PR DESCRIPTION
Upgrade KCC to v1.116.0.
Add cmd in `README.md` to clean up downloaded files after KCC upgrade.

Release notes: https://github.com/GoogleCloudPlatform/k8s-config-connector/releases/tag/v1.116.0