### PR TITLE
chore: remove alpha DNS zones

### DIFF
--- a/infrastructure/dns-zone.yaml
+++ b/infrastructure/dns-zone.yaml
@@ -1,34 +1,3 @@
-apiVersion: dns.cnrm.cloud.google.com/v1beta1
-kind: DNSManagedZone
-metadata:
-  name: hopic-managed-zone
-  namespace: cnrm-system
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: merge
-spec:
-  cloudLoggingConfig:
-    enableLogging: true
-  description: HoPiC DNS Zone for alpha DNS
-  dnsName: hopic-sdpac.phac-aspc.alpha.canada.ca.
-  visibility: public
----
-apiVersion: dns.cnrm.cloud.google.com/v1beta1
-kind: DNSRecordSet
-metadata:
-  name: hopic-dns-record-set
-  namespace: cnrm-system
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: merge
-spec:
-  name: "hopic-sdpac.phac-aspc.alpha.canada.ca."
-  type: A
-  ttl: 300
-  managedZoneRef:
-    name: hopic-managed-zone
-  rrdatasRefs:
-    - name: hopic-external-ip
-      kind: ComputeAddress
----
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeAddress
 metadata:
@@ -41,24 +10,6 @@ spec:
   description: HoPiC external ip address for ingress gateway
   location: northamerica-northeast1
   networkTier: STANDARD
----
-# ephemeral DNS config
-apiVersion: dns.cnrm.cloud.google.com/v1beta1
-kind: DNSRecordSet
-metadata:
-  name: hopic-ephemeral-dns-record-set
-  namespace: cnrm-system
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: merge
-spec:
-  name: "*.dev.hopic-sdpac.phac-aspc.alpha.canada.ca."
-  type: A
-  ttl: 300
-  managedZoneRef:
-    name: hopic-managed-zone
-  rrdatasRefs:
-    - name: hopic-external-ip
-      kind: ComputeAddress
 ---
 apiVersion: dns.cnrm.cloud.google.com/v1beta1
 kind: DNSManagedZone


### PR DESCRIPTION
Remove alpha DNS zones.

Although it was discussed in https://github.com/PHACDataHub/cpho-phase2/pull/311 that we'd want to keep the alpha zones around since SSO works, the [upstream dns service](https://github.com/PHACDataHub/dns) will soon be deprecated in favour of the [new one](https://github.com/PHACDataHub/phac-dns/tree/main) and therefore, the hopic subdomain on `phac-aspc.alpha.canada.ca` won't work.