### PR TITLE
chore: upgrade cnpg op `1.23.1`

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -154,7 +154,7 @@ There are two types of updates in this section:
 
 ### Operator
 
-To [upgrade cnpg operator](https://cloudnative-pg.io/documentation/1.22/installation_upgrade/#upgrades) on the cluster, run the following commands from the root of this repository and submit a PR with changes:
+To [upgrade cnpg operator](https://cloudnative-pg.io/documentation/current/installation_upgrade/#upgrades) on the cluster, run the following commands from the root of this repository and submit a PR with changes:
 
 ```sh
 curl -sSL https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v<VERISON>/cnpg-<VERSION>.yaml > ./k8s/cnpg-system/cnpg-crds.yaml

--- a/k8s/cnpg-system/cnpg-crds.yaml
+++ b/k8s/cnpg-system/cnpg-crds.yaml
@@ -1,5 +1,4 @@
-# https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.22/releases/cnpg-1.22.2.yaml
-# See https://cloudnative-pg.io/documentation/1.22/installation_upgrade/ for installation details
+# https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.23/releases/cnpg-1.23.1.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -77,11 +76,12 @@ spec:
               method:
                 default: barmanObjectStore
                 description: |-
-                  The backup method to be used, possible options are `barmanObjectStore`
-                  and `volumeSnapshot`. Defaults to: `barmanObjectStore`.
+                  The backup method to be used, possible options are `barmanObjectStore`,
+                  `volumeSnapshot` or `plugin`. Defaults to: `barmanObjectStore`.
                 enum:
                 - barmanObjectStore
                 - volumeSnapshot
+                - plugin
                 type: string
               online:
                 description: |-
@@ -115,6 +115,23 @@ spec:
                       If write activity on the primary is low, it may be useful to run pg_switch_wal on the primary in order to trigger
                       an immediate segment switch.
                     type: boolean
+                type: object
+              pluginConfiguration:
+                description: Configuration parameters passed to the plugin managing
+                  this backup
+                properties:
+                  name:
+                    description: Name is the name of the plugin managing this backup
+                    type: string
+                  parameters:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Parameters are the configuration parameters passed to the backup
+                      plugin for this backup
+                    type: object
+                required:
+                - name
                 type: object
               target:
                 description: |-
@@ -424,6 +441,87 @@ spec:
     storage: true
     subresources:
       status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: clusterimagecatalogs.postgresql.cnpg.io
+spec:
+  group: postgresql.cnpg.io
+  names:
+    kind: ClusterImageCatalog
+    listKind: ClusterImageCatalogList
+    plural: clusterimagecatalogs
+    singular: clusterimagecatalog
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ClusterImageCatalog is the Schema for the clusterimagecatalogs
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired behavior of the ClusterImageCatalog.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              images:
+                description: List of CatalogImages available in the catalog
+                items:
+                  description: CatalogImage defines the image and major version
+                  properties:
+                    image:
+                      description: The image reference
+                      type: string
+                    major:
+                      description: The PostgreSQL major version of the image. Must
+                        be unique within the catalog.
+                      minimum: 10
+                      type: integer
+                  required:
+                  - image
+                  - major
+                  type: object
+                maxItems: 8
+                minItems: 1
+                type: array
+                x-kubernetes-validations:
+                - message: Images must have unique major versions
+                  rule: self.all(e, self.filter(f, f.major==e.major).size() == 1)
+            required:
+            - images
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2303,6 +2401,18 @@ spec:
               description:
                 description: Description of this PostgreSQL cluster
                 type: string
+              enablePDB:
+                default: true
+                description: |-
+                  Manage the `PodDisruptionBudget` resources within the cluster. When
+                  configured as `true` (default setting), the pod disruption budgets
+                  will safeguard the primary node from being terminated. Conversely,
+                  setting it to `false` will result in the absence of any
+                  `PodDisruptionBudget` resource, permitting the shutdown of all nodes
+                  hosting the PostgreSQL cluster. This latter configuration is
+                  advisable for any PostgreSQL cluster employed for
+                  development/staging purposes.
+                type: boolean
               enableSuperuserAccess:
                 default: false
                 description: |-
@@ -3156,6 +3266,40 @@ spec:
                   to be unhealthy
                 format: int32
                 type: integer
+              imageCatalogRef:
+                description: Defines the major PostgreSQL version we want to use within
+                  an ImageCatalog
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  major:
+                    description: The major version of PostgreSQL we want to use from
+                      the ImageCatalog
+                    type: integer
+                    x-kubernetes-validations:
+                    - message: Major is immutable
+                      rule: self == oldSelf
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - major
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Only image catalogs are supported
+                  rule: self.kind == 'ImageCatalog' || self.kind == 'ClusterImageCatalog'
+                - message: Only image catalogs are supported
+                  rule: self.apiGroup == 'postgresql.cnpg.io'
               imageName:
                 description: |-
                   Name of the container image, supporting both tags (`<image>:<tag>`)
@@ -3602,6 +3746,27 @@ spec:
                       up again) or not (recreate it elsewhere - when `instances` >1)
                     type: boolean
                 type: object
+              plugins:
+                description: |-
+                  The plugins configuration, containing
+                  any plugin to be loaded with the corresponding configuration
+                items:
+                  description: |-
+                    PluginConfiguration specifies a plugin that need to be loaded for this
+                    cluster to be reconciled
+                  properties:
+                    name:
+                      description: Name is the plugin name
+                      type: string
+                    parameters:
+                      additionalProperties:
+                        type: string
+                      description: Parameters is the configuration of the plugin
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
               postgresGID:
                 default: 26
                 description: The GID of the `postgres` user inside the image, defaults
@@ -4147,6 +4312,25 @@ spec:
                           This can only be set at creation time. By default set to `_cnpg_`.
                         pattern: ^[0-9a-z_]*$
                         type: string
+                    type: object
+                  synchronizeReplicas:
+                    description: Configures the synchronization of the user defined
+                      physical replication slots
+                    properties:
+                      enabled:
+                        default: true
+                        description: When set to true, every replication slot that
+                          is on the primary is synchronized on each standby
+                        type: boolean
+                      excludePatterns:
+                        description: List of regular expression patterns to match
+                          the names of replication slots to be excluded (by default
+                          empty)
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - enabled
                     type: object
                   updateInterval:
                     default: 30
@@ -5188,6 +5372,9 @@ spec:
             required:
             - instances
             type: object
+            x-kubernetes-validations:
+            - message: imageName and imageCatalogRef are mutually exclusive
+              rule: '!(has(self.imageCatalogRef) && has(self.imageName))'
           status:
             description: |-
               Most recently observed status of the cluster. This data may not be up
@@ -5397,6 +5584,9 @@ spec:
                 items:
                   type: string
                 type: array
+              image:
+                description: Image contains the image name used by the pods
+                type: string
               initializingPVC:
                 description: List of all the PVCs that are being initialized by this
                   cluster
@@ -5508,6 +5698,52 @@ spec:
               phaseReason:
                 description: Reason for the current phase
                 type: string
+              pluginStatus:
+                description: PluginStatus is the status of the loaded plugins
+                items:
+                  description: PluginStatus is the status of a loaded plugin
+                  properties:
+                    backupCapabilities:
+                      description: |-
+                        BackupCapabilities are the list of capabilities of the
+                        plugin regarding the Backup management
+                      items:
+                        type: string
+                      type: array
+                    capabilities:
+                      description: |-
+                        Capabilities are the list of capabilities of the
+                        plugin
+                      items:
+                        type: string
+                      type: array
+                    name:
+                      description: Name is the name of the plugin
+                      type: string
+                    operatorCapabilities:
+                      description: |-
+                        OperatorCapabilities are the list of capabilities of the
+                        plugin regarding the reconciler
+                      items:
+                        type: string
+                      type: array
+                    version:
+                      description: |-
+                        Version is the version of the plugin loaded by the
+                        latest reconciliation loop
+                      type: string
+                    walCapabilities:
+                      description: |-
+                        WALCapabilities are the list of capabilities of the
+                        plugin regarding the WAL management
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
               poolerIntegrations:
                 description: The integration needed by poolers referencing the cluster
                 properties:
@@ -5590,6 +5826,15 @@ spec:
                   superuserSecretVersion:
                     description: The resource version of the "postgres" user secret
                     type: string
+                type: object
+              switchReplicaClusterStatus:
+                description: SwitchReplicaClusterStatus is the status of the switch
+                  to replica cluster
+                properties:
+                  inProgress:
+                    description: InProgress indicates if there is an ongoing procedure
+                      of switching a cluster to a replica cluster.
+                    type: boolean
                 type: object
               tablespacesStatus:
                 description: TablespacesStatus reports the state of the declarative
@@ -5675,6 +5920,86 @@ spec:
         specReplicasPath: .spec.instances
         statusReplicasPath: .status.instances
       status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: imagecatalogs.postgresql.cnpg.io
+spec:
+  group: postgresql.cnpg.io
+  names:
+    kind: ImageCatalog
+    listKind: ImageCatalogList
+    plural: imagecatalogs
+    singular: imagecatalog
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ImageCatalog is the Schema for the imagecatalogs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired behavior of the ImageCatalog.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              images:
+                description: List of CatalogImages available in the catalog
+                items:
+                  description: CatalogImage defines the image and major version
+                  properties:
+                    image:
+                      description: The image reference
+                      type: string
+                    major:
+                      description: The PostgreSQL major version of the image. Must
+                        be unique within the catalog.
+                      minimum: 10
+                      type: integer
+                  required:
+                  - image
+                  - major
+                  type: object
+                maxItems: 8
+                minItems: 1
+                type: array
+                x-kubernetes-validations:
+                - message: Images must have unique major versions
+                  rule: self.all(e, self.filter(f, f.major==e.major).size() == 1)
+            required:
+            - images
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -6046,6 +6371,372 @@ spec:
                     - session
                     - transaction
                     type: string
+                type: object
+              serviceTemplate:
+                description: Template for the Service to be created
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: |-
+                      Specification of the desired behavior of the service.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      allocateLoadBalancerNodePorts:
+                        description: |-
+                          allocateLoadBalancerNodePorts defines if NodePorts will be automatically
+                          allocated for services with type LoadBalancer.  Default is "true". It
+                          may be set to "false" if the cluster load-balancer does not rely on
+                          NodePorts.  If the caller requests specific NodePorts (by specifying a
+                          value), those requests will be respected, regardless of this field.
+                          This field may only be set for services with type LoadBalancer and will
+                          be cleared if the type is changed to any other type.
+                        type: boolean
+                      clusterIP:
+                        description: |-
+                          clusterIP is the IP address of the service and is usually assigned
+                          randomly. If an address is specified manually, is in-range (as per
+                          system configuration), and is not in use, it will be allocated to the
+                          service; otherwise creation of the service will fail. This field may not
+                          be changed through updates unless the type field is also being changed
+                          to ExternalName (which requires this field to be blank) or the type
+                          field is being changed from ExternalName (in which case this field may
+                          optionally be specified, as describe above).  Valid values are "None",
+                          empty string (""), or a valid IP address. Setting this to "None" makes a
+                          "headless service" (no virtual IP), which is useful when direct endpoint
+                          connections are preferred and proxying is not required.  Only applies to
+                          types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+                          when creating a Service of type ExternalName, creation will fail. This
+                          field will be wiped when updating a Service to type ExternalName.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                        type: string
+                      clusterIPs:
+                        description: |-
+                          ClusterIPs is a list of IP addresses assigned to this service, and are
+                          usually assigned randomly.  If an address is specified manually, is
+                          in-range (as per system configuration), and is not in use, it will be
+                          allocated to the service; otherwise creation of the service will fail.
+                          This field may not be changed through updates unless the type field is
+                          also being changed to ExternalName (which requires this field to be
+                          empty) or the type field is being changed from ExternalName (in which
+                          case this field may optionally be specified, as describe above).  Valid
+                          values are "None", empty string (""), or a valid IP address.  Setting
+                          this to "None" makes a "headless service" (no virtual IP), which is
+                          useful when direct endpoint connections are preferred and proxying is
+                          not required.  Only applies to types ClusterIP, NodePort, and
+                          LoadBalancer. If this field is specified when creating a Service of type
+                          ExternalName, creation will fail. This field will be wiped when updating
+                          a Service to type ExternalName.  If this field is not specified, it will
+                          be initialized from the clusterIP field.  If this field is specified,
+                          clients must ensure that clusterIPs[0] and clusterIP have the same
+                          value.
+
+
+                          This field may hold a maximum of two entries (dual-stack IPs, in either order).
+                          These IPs must correspond to the values of the ipFamilies field. Both
+                          clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      externalIPs:
+                        description: |-
+                          externalIPs is a list of IP addresses for which nodes in the cluster
+                          will also accept traffic for this service.  These IPs are not managed by
+                          Kubernetes.  The user is responsible for ensuring that traffic arrives
+                          at a node with this IP.  A common example is external load-balancers
+                          that are not part of the Kubernetes system.
+                        items:
+                          type: string
+                        type: array
+                      externalName:
+                        description: |-
+                          externalName is the external reference that discovery mechanisms will
+                          return as an alias for this service (e.g. a DNS CNAME record). No
+                          proxying will be involved.  Must be a lowercase RFC-1123 hostname
+                          (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+                        type: string
+                      externalTrafficPolicy:
+                        description: |-
+                          externalTrafficPolicy describes how nodes distribute service traffic they
+                          receive on one of the Service's "externally-facing" addresses (NodePorts,
+                          ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure
+                          the service in a way that assumes that external load balancers will take care
+                          of balancing the service traffic between nodes, and so each node will deliver
+                          traffic only to the node-local endpoints of the service, without masquerading
+                          the client source IP. (Traffic mistakenly sent to a node with no endpoints will
+                          be dropped.) The default value, "Cluster", uses the standard behavior of
+                          routing to all endpoints evenly (possibly modified by topology and other
+                          features). Note that traffic sent to an External IP or LoadBalancer IP from
+                          within the cluster will always get "Cluster" semantics, but clients sending to
+                          a NodePort from within the cluster may need to take traffic policy into account
+                          when picking a node.
+                        type: string
+                      healthCheckNodePort:
+                        description: |-
+                          healthCheckNodePort specifies the healthcheck nodePort for the service.
+                          This only applies when type is set to LoadBalancer and
+                          externalTrafficPolicy is set to Local. If a value is specified, is
+                          in-range, and is not in use, it will be used.  If not specified, a value
+                          will be automatically allocated.  External systems (e.g. load-balancers)
+                          can use this port to determine if a given node holds endpoints for this
+                          service or not.  If this field is specified when creating a Service
+                          which does not need it, creation will fail. This field will be wiped
+                          when updating a Service to no longer need it (e.g. changing type).
+                          This field cannot be updated once set.
+                        format: int32
+                        type: integer
+                      internalTrafficPolicy:
+                        description: |-
+                          InternalTrafficPolicy describes how nodes distribute service traffic they
+                          receive on the ClusterIP. If set to "Local", the proxy will assume that pods
+                          only want to talk to endpoints of the service on the same node as the pod,
+                          dropping the traffic if there are no local endpoints. The default value,
+                          "Cluster", uses the standard behavior of routing to all endpoints evenly
+                          (possibly modified by topology and other features).
+                        type: string
+                      ipFamilies:
+                        description: |-
+                          IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this
+                          service. This field is usually assigned automatically based on cluster
+                          configuration and the ipFamilyPolicy field. If this field is specified
+                          manually, the requested family is available in the cluster,
+                          and ipFamilyPolicy allows it, it will be used; otherwise creation of
+                          the service will fail. This field is conditionally mutable: it allows
+                          for adding or removing a secondary IP family, but it does not allow
+                          changing the primary IP family of the Service. Valid values are "IPv4"
+                          and "IPv6".  This field only applies to Services of types ClusterIP,
+                          NodePort, and LoadBalancer, and does apply to "headless" services.
+                          This field will be wiped when updating a Service to type ExternalName.
+
+
+                          This field may hold a maximum of two entries (dual-stack families, in
+                          either order).  These families must correspond to the values of the
+                          clusterIPs field, if specified. Both clusterIPs and ipFamilies are
+                          governed by the ipFamilyPolicy field.
+                        items:
+                          description: |-
+                            IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                            to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      ipFamilyPolicy:
+                        description: |-
+                          IPFamilyPolicy represents the dual-stack-ness requested or required by
+                          this Service. If there is no value provided, then this field will be set
+                          to SingleStack. Services can be "SingleStack" (a single IP family),
+                          "PreferDualStack" (two IP families on dual-stack configured clusters or
+                          a single IP family on single-stack clusters), or "RequireDualStack"
+                          (two IP families on dual-stack configured clusters, otherwise fail). The
+                          ipFamilies and clusterIPs fields depend on the value of this field. This
+                          field will be wiped when updating a service to type ExternalName.
+                        type: string
+                      loadBalancerClass:
+                        description: |-
+                          loadBalancerClass is the class of the load balancer implementation this Service belongs to.
+                          If specified, the value of this field must be a label-style identifier, with an optional prefix,
+                          e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+                          This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load
+                          balancer implementation is used, today this is typically done through the cloud provider integration,
+                          but should apply for any default implementation. If set, it is assumed that a load balancer
+                          implementation is watching for Services with a matching class. Any default load balancer
+                          implementation (e.g. cloud providers) should ignore Services that set this field.
+                          This field can only be set when creating or updating a Service to type 'LoadBalancer'.
+                          Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+                        type: string
+                      loadBalancerIP:
+                        description: |-
+                          Only applies to Service Type: LoadBalancer.
+                          This feature depends on whether the underlying cloud-provider supports specifying
+                          the loadBalancerIP when a load balancer is created.
+                          This field will be ignored if the cloud-provider does not support the feature.
+                          Deprecated: This field was under-specified and its meaning varies across implementations.
+                          Using it is non-portable and it may not support dual-stack.
+                          Users are encouraged to use implementation-specific annotations when available.
+                        type: string
+                      loadBalancerSourceRanges:
+                        description: |-
+                          If specified and supported by the platform, this will restrict traffic through the cloud-provider
+                          load-balancer will be restricted to the specified client IPs. This field will be ignored if the
+                          cloud-provider does not support the feature."
+                          More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
+                        items:
+                          type: string
+                        type: array
+                      ports:
+                        description: |-
+                          The list of ports that are exposed by this service.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                        items:
+                          description: ServicePort contains information on service's
+                            port.
+                          properties:
+                            appProtocol:
+                              description: |-
+                                The application protocol for this port.
+                                This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                                This field follows standard Kubernetes label syntax.
+                                Valid values are either:
+
+
+                                * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                                RFC-6335 and https://www.iana.org/assignments/service-names).
+
+
+                                * Kubernetes-defined prefixed names:
+                                  * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                                  * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                                  * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+
+
+                                * Other protocols should use implementation-defined prefixed names such as
+                                mycompany.com/my-custom-protocol.
+                              type: string
+                            name:
+                              description: |-
+                                The name of this port within the service. This must be a DNS_LABEL.
+                                All ports within a ServiceSpec must have unique names. When considering
+                                the endpoints for a Service, this must match the 'name' field in the
+                                EndpointPort.
+                                Optional if only one ServicePort is defined on this service.
+                              type: string
+                            nodePort:
+                              description: |-
+                                The port on each node on which this service is exposed when type is
+                                NodePort or LoadBalancer.  Usually assigned by the system. If a value is
+                                specified, in-range, and not in use it will be used, otherwise the
+                                operation will fail.  If not specified, a port will be allocated if this
+                                Service requires one.  If this field is specified when creating a
+                                Service which does not need it, creation will fail. This field will be
+                                wiped when updating a Service to no longer need it (e.g. changing type
+                                from NodePort to ClusterIP).
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+                              format: int32
+                              type: integer
+                            port:
+                              description: The port that will be exposed by this service.
+                              format: int32
+                              type: integer
+                            protocol:
+                              default: TCP
+                              description: |-
+                                The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                                Default is TCP.
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                Number or name of the port to access on the pods targeted by the service.
+                                Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                If this is a string, it will be looked up as a named port in the
+                                target Pod's container ports. If this is not specified, the value
+                                of the 'port' field is used (an identity map).
+                                This field is ignored for services with clusterIP=None, and should be
+                                omitted or set equal to the 'port' field.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - port
+                        - protocol
+                        x-kubernetes-list-type: map
+                      publishNotReadyAddresses:
+                        description: |-
+                          publishNotReadyAddresses indicates that any agent which deals with endpoints for this
+                          Service should disregard any indications of ready/not-ready.
+                          The primary use case for setting this field is for a StatefulSet's Headless Service to
+                          propagate SRV DNS records for its Pods for the purpose of peer discovery.
+                          The Kubernetes controllers that generate Endpoints and EndpointSlice resources for
+                          Services interpret this to mean that all endpoints are considered "ready" even if the
+                          Pods themselves are not. Agents which consume only Kubernetes generated endpoints
+                          through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                        type: boolean
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Route service traffic to pods with label keys and values matching this
+                          selector. If empty or not present, the service is assumed to have an
+                          external process managing its endpoints, which Kubernetes will not
+                          modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+                          Ignored if type is ExternalName.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      sessionAffinity:
+                        description: |-
+                          Supports "ClientIP" and "None". Used to maintain session affinity.
+                          Enable client IP based session affinity.
+                          Must be ClientIP or None.
+                          Defaults to None.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                        type: string
+                      sessionAffinityConfig:
+                        description: sessionAffinityConfig contains the configurations
+                          of session affinity.
+                        properties:
+                          clientIP:
+                            description: clientIP contains the configurations of Client
+                              IP based session affinity.
+                            properties:
+                              timeoutSeconds:
+                                description: |-
+                                  timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+                                  The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+                                  Default value is 10800(for 3 hours).
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      type:
+                        description: |-
+                          type determines how the Service is exposed. Defaults to ClusterIP. Valid
+                          options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
+                          "ClusterIP" allocates a cluster-internal IP address for load-balancing
+                          to endpoints. Endpoints are determined by the selector or if that is not
+                          specified, by manual construction of an Endpoints object or
+                          EndpointSlice objects. If clusterIP is "None", no virtual IP is
+                          allocated and the endpoints are published as a set of endpoints rather
+                          than a virtual IP.
+                          "NodePort" builds on ClusterIP and allocates a port on every node which
+                          routes to the same endpoints as the clusterIP.
+                          "LoadBalancer" builds on NodePort and creates an external load-balancer
+                          (if supported in the current cloud) which routes to the same endpoints
+                          as the clusterIP.
+                          "ExternalName" aliases this service to the specified externalName.
+                          Several other fields do not apply to ExternalName services.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+                        type: string
+                    type: object
                 type: object
               template:
                 description: The template of the Pod to be created
@@ -13745,6 +14436,23 @@ spec:
                       an immediate segment switch.
                     type: boolean
                 type: object
+              pluginConfiguration:
+                description: Configuration parameters passed to the plugin managing
+                  this backup
+                properties:
+                  name:
+                    description: Name is the name of the plugin managing this backup
+                    type: string
+                  parameters:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Parameters are the configuration parameters passed to the backup
+                      plugin for this backup
+                    type: object
+                required:
+                - name
+                type: object
               schedule:
                 description: |-
                   The schedule does not follow the same format used in Kubernetes CronJobs
@@ -14038,6 +14746,14 @@ rules:
 - apiGroups:
   - postgresql.cnpg.io
   resources:
+  - clusterimagecatalogs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - postgresql.cnpg.io
+  resources:
   - clusters
   verbs:
   - create
@@ -14061,6 +14777,14 @@ rules:
   - get
   - patch
   - update
+  - watch
+- apiGroups:
+  - postgresql.cnpg.io
+  resources:
+  - imagecatalogs
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - postgresql.cnpg.io
@@ -14353,6 +15077,7 @@ data:
             description: "Time at which these statistics were last reset"
 
     pg_stat_bgwriter:
+      runonserver: "<17.0.0"
       query: |
         SELECT checkpoints_timed
           , checkpoints_req
@@ -14585,14 +15310,14 @@ spec:
         - /manager
         env:
         - name: OPERATOR_IMAGE_NAME
-          value: ghcr.io/cloudnative-pg/cloudnative-pg:1.22.2
+          value: ghcr.io/cloudnative-pg/cloudnative-pg:1.23.1
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
         - name: MONITORING_QUERIES_CONFIGMAP
           value: cnpg-default-monitoring
-        image: ghcr.io/cloudnative-pg/cloudnative-pg:1.22.2
+        image: ghcr.io/cloudnative-pg/cloudnative-pg:1.23.1
         livenessProbe:
           httpGet:
             path: /readyz

--- a/k8s/cnpg-system/kustomization.yaml
+++ b/k8s/cnpg-system/kustomization.yaml
@@ -28,15 +28,13 @@ patches:
                 resources:
                   requests:
                     cpu: 200m
-                    memory: 400Mi   
+                    memory: 400Mi
               - name: istio-proxy
                 image: auto
                 resources:
                   requests:
                     cpu: 50m
-                    memory: 112Mi   
-                securityContext:
-                  allowPrivilegeEscalation: false
+                    memory: 112Mi
     target:
       kind: Deployment
       name: cnpg-controller-manager


### PR DESCRIPTION
Upgrade CNPG operator to `1.23.1`
Update CNPG doc reference to `current`
Remove `securityContext` block since it's already set in the CRDs

Release notes: https://github.com/cloudnative-pg/cloudnative-pg/releases/tag/v1.23.1