### PR TITLE
feat: add data zone

### DIFF
--- a/infrastructure/dns-zone.yaml
+++ b/infrastructure/dns-zone.yaml
@@ -95,7 +95,7 @@ spec:
 apiVersion: dns.cnrm.cloud.google.com/v1beta1
 kind: DNSRecordSet
 metadata:
-  name: hopic-ops-ephemeral-dns-record-set
+  name: hopic-uni-ephemeral-dns-record-set
   namespace: cnrm-system
   annotations:
     cnrm.cloud.google.com/state-into-spec: merge

--- a/infrastructure/dns-zone.yaml
+++ b/infrastructure/dns-zone.yaml
@@ -59,3 +59,52 @@ spec:
   rrdatasRefs:
     - name: hopic-external-ip
       kind: ComputeAddress
+---
+apiVersion: dns.cnrm.cloud.google.com/v1beta1
+kind: DNSManagedZone
+metadata:
+  name: hopic-uni-managed-zone
+  namespace: cnrm-system
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: merge
+spec:
+  cloudLoggingConfig:
+    enableLogging: true
+  description: HoPiC DNS Zone for production DNS
+  dnsName: hopic-sdpac.data.phac.gc.ca.
+  visibility: public
+---
+apiVersion: dns.cnrm.cloud.google.com/v1beta1
+kind: DNSRecordSet
+metadata:
+  name: hopic-uni-dns-record-set
+  namespace: cnrm-system
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: merge
+spec:
+  name: "hopic-sdpac.data.phac.gc.ca."
+  type: A
+  ttl: 300
+  managedZoneRef:
+    name: hopic-uni-managed-zone
+  rrdatasRefs:
+    - name: hopic-external-ip
+      kind: ComputeAddress
+---
+# ephemeral DNS config
+apiVersion: dns.cnrm.cloud.google.com/v1beta1
+kind: DNSRecordSet
+metadata:
+  name: hopic-ops-ephemeral-dns-record-set
+  namespace: cnrm-system
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: merge
+spec:
+  name: "*.dev.hopic-sdpac.data.phac.gc.ca."
+  type: A
+  ttl: 300
+  managedZoneRef:
+    name: hopic-uni-managed-zone
+  rrdatasRefs:
+    - name: hopic-external-ip
+      kind: ComputeAddress


### PR DESCRIPTION
Since `hopic-sdpac.data-donnes.phac-aspc.gc.ca` fails to resolve on the office network due to an upstream configuration issue with `phac-aspc.gc.ca`, we'll be eventually moving off to `data.phac.gc.ca`. 

This PR adds the infrastructure to make it work.

Traffic routing configurations will follow in separate PR once the DNS delegation for `hopic-sdpac` subdomain is configured with the [phac-dns](https://github.com/PHACDataHub/phac-dns).