### PR TITLE
feat: add year-filterable datum changelog

### DIFF
--- a/server/cpho/jinja2/base.jinja2
+++ b/server/cpho/jinja2/base.jinja2
@@ -103,11 +103,15 @@
                         <span aria-hidden="true" class="bi bi-people"></span>
                         {{ tm("user_management") }}
                       </a>
+                      <a class="dropdown-item" href="{{ url("global_changelog") }}">
+                        <span aria-hidden="true" class="bi bi-file-diff"></span>
+                        {{ tm("changelog") }}
+                      </a>
+                      <a class="dropdown-item" href="{{ url("global_datum_changelog") }}">
+                        <span aria-hidden="true" class="bi bi-file-diff"></span>
+                        {{ tdt("datum changelog") }}
+                      </a>
                     {% endif %}
-                    <a class="dropdown-item" href="{{ url("global_changelog") }}">
-                      <span aria-hidden="true" class="bi bi-file-diff"></span>
-                      {{ tm("changelog") }}
-                    </a>
                     {% if respects_rule('is_admin_or_hso') %}
                       <a class="dropdown-item" href="{{ url("infobase_export") }}">
                         <i aria-hidden="true" class="bi bi-file-earmark-excel"></i>

--- a/server/cpho/model_factories.py
+++ b/server/cpho/model_factories.py
@@ -27,9 +27,9 @@ class CountryFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Country
 
+    id = factory.Faker("pyint", min_value=1, max_value=999999)
     name_en = factory.Faker("bs")
     name_fr = factory.Faker("bs")
-    code = factory.Faker("bs")
 
 
 class DimensionValueFactory(factory.django.DjangoModelFactory):

--- a/server/cpho/urls.py
+++ b/server/cpho/urls.py
@@ -136,6 +136,16 @@ urlpatterns = [
         name="global_changelog",
     ),
     path(
+        "global-datum-changelog/indicator_datum/",
+        views.GlobalDatumChangelog.as_view(),
+        name="global_datum_changelog",
+    ),
+    path(
+        "global-datum-changelog/<int:page_num>/",
+        views.GlobalDatumChangelog.as_view(),
+        name="global_datum_changelog",
+    ),
+    path(
         "indicators/<int:pk>/export/",
         views.ExportIndicator.as_view(),
         name="export_indicator",

--- a/server/tests/test_changelog.py
+++ b/server/tests/test_changelog.py
@@ -6,7 +6,11 @@ from django.urls import reverse
 
 from phac_aspc.rules import patch_rules
 
-from cpho.model_factories import IndicatorFactory
+from cpho.model_factories import (
+    BenchmarkingFactory,
+    IndicatorFactory,
+    TrendAnalysisFactory,
+)
 from cpho.models import (
     DimensionType,
     DimensionValue,
@@ -61,6 +65,27 @@ def create_versions():
         period=p2, dimension_type=s_cat, dimension_value=f_val, value=8
     )
 
+    # also create some benchmarking and trend analysis
+    bm1 = BenchmarkingFactory(indicator=i1, value=1)
+    bm1.reset_version_attrs()
+    bm1.value = 1.1
+    bm1.save()
+
+    bm2 = BenchmarkingFactory(value=2, indicator=i2)
+    bm2.reset_version_attrs()
+    bm2.value = 2.2
+    bm2.save()
+
+    ta1 = TrendAnalysisFactory(indicator=i1, data_point=1)
+    ta1.reset_version_attrs()
+    ta1.data_point = 1.1
+    ta1.save()
+
+    ta2 = TrendAnalysisFactory(indicator=i2, data_point=2)
+    ta2.reset_version_attrs()
+    ta2.data_point = 2.2
+    ta2.save()
+
 
 def test_global_changelog(vanilla_user_client):
     create_versions()
@@ -79,7 +104,7 @@ def test_global_changelog(vanilla_user_client):
     ):
         resp = vanilla_user_client.get(reverse("global_changelog"))
         assert resp.status_code == 200
-        assert resp.context["num_pages"] == 7
+        assert resp.context["num_pages"] == 11
         assert resp.context["page_num"] == 1
 
         resp = vanilla_user_client.get(
@@ -121,7 +146,7 @@ def test_indicator_changelog(vanilla_user_client):
             )
         )
         assert resp.status_code == 200
-        assert resp.context["num_pages"] == 4
+        assert resp.context["num_pages"] == 6
         assert resp.context["page_num"] == 1
 
         resp = vanilla_user_client.get(


### PR DESCRIPTION
This is just the global changelog but just for the indicator-datum model, and you can add `?year=2023` on the URL to fitler to a particular year