### PR TITLE
feat: set `state-into-spec` in ConfigConnectorContext

### DIFF
--- a/infrastructure/artifactregistry.yaml
+++ b/infrastructure/artifactregistry.yaml
@@ -3,8 +3,6 @@ kind: ArtifactRegistryRepository
 metadata:
   name: hopic-k8s-images
   namespace: cnrm-system
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   description: Artifact registry for HoPiC docker images
   format: DOCKER

--- a/infrastructure/cloudbuildtrigger.yaml
+++ b/infrastructure/cloudbuildtrigger.yaml
@@ -3,8 +3,6 @@ kind: CloudBuildTrigger
 metadata:
   name: hopic-cloudbuild-trigger
   namespace: cnrm-system
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   description: Cloud Build Trigger for building docker images from GitHub repository at https://github.com/PHACDataHub/cpho-phase2/
   disabled: false

--- a/infrastructure/dns-zone.yaml
+++ b/infrastructure/dns-zone.yaml
@@ -3,8 +3,6 @@ kind: ComputeAddress
 metadata:
   name: hopic-external-ip
   namespace: cnrm-system
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   addressType: EXTERNAL
   description: HoPiC external ip address for ingress gateway
@@ -16,8 +14,6 @@ kind: DNSManagedZone
 metadata:
   name: hopic-ops-managed-zone
   namespace: cnrm-system
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   cloudLoggingConfig:
     enableLogging: true
@@ -30,8 +26,6 @@ kind: DNSRecordSet
 metadata:
   name: hopic-ops-dns-record-set
   namespace: cnrm-system
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   name: "hopic-sdpac.data-donnes.phac-aspc.gc.ca."
   type: A
@@ -48,8 +42,6 @@ kind: DNSRecordSet
 metadata:
   name: hopic-ops-ephemeral-dns-record-set
   namespace: cnrm-system
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   name: "*.dev.hopic-sdpac.data-donnes.phac-aspc.gc.ca."
   type: A
@@ -65,8 +57,6 @@ kind: DNSManagedZone
 metadata:
   name: hopic-uni-managed-zone
   namespace: cnrm-system
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   cloudLoggingConfig:
     enableLogging: true
@@ -79,8 +69,6 @@ kind: DNSRecordSet
 metadata:
   name: hopic-uni-dns-record-set
   namespace: cnrm-system
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   name: "hopic-sdpac.data.phac.gc.ca."
   type: A
@@ -97,8 +85,6 @@ kind: DNSRecordSet
 metadata:
   name: hopic-uni-ephemeral-dns-record-set
   namespace: cnrm-system
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   name: "*.dev.hopic-sdpac.data.phac.gc.ca."
   type: A

--- a/infrastructure/dnspolicy.yaml
+++ b/infrastructure/dnspolicy.yaml
@@ -3,8 +3,6 @@ kind: DNSPolicy
 metadata:
   name: hopic-net-dnspolicy
   namespace: cnrm-system
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   description: "Enables DNS logging for the hopic-net VPC"
   enableLogging: true

--- a/infrastructure/kms.yaml
+++ b/infrastructure/kms.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: cnrm-system
   annotations:
     cnrm.cloud.google.com/deletion-policy: abandon
-    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   keyRingRef:
     name: sops
@@ -17,7 +16,5 @@ kind: KMSKeyRing
 metadata:
   name: sops
   namespace: cnrm-system
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   location: northamerica-northeast1

--- a/infrastructure/logging-bucket.yaml
+++ b/infrastructure/logging-bucket.yaml
@@ -4,8 +4,6 @@ kind: LoggingLogBucket
 metadata:
   name: hopic-application-logs-pht-01hp04dtnkf
   namespace: cnrm-system
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   projectRef:
     external: "projects/pht-01hp04dtnkf"
@@ -22,8 +20,6 @@ kind: LoggingLogSink
 metadata:
   namespace: cnrm-system
   name: hopic-application-logs-sink
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   projectRef:
     external: "pht-01hp04dtnkf"

--- a/infrastructure/proxy-subnet.yaml
+++ b/infrastructure/proxy-subnet.yaml
@@ -3,8 +3,6 @@ kind: ComputeSubnetwork
 metadata:
   name: proxy-only-subnet
   namespace: cnrm-system
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   ipCidrRange: 10.129.0.0/23
   region: northamerica-northeast1

--- a/infrastructure/service-account.yaml
+++ b/infrastructure/service-account.yaml
@@ -3,8 +3,6 @@ kind: IAMServiceAccount
 metadata:
   name: gcr-credentials-sync
   namespace: cnrm-system
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   displayName: gcr-credentials-sync
   description: To obtain artifact registry credentials for image reconciliations in Flux
@@ -25,8 +23,6 @@ kind: IAMServiceAccount
 metadata:
   name: hopic-postgres-backup
   namespace: cnrm-system
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   displayName: hopic-postgres-backup
   description: To backup cloudnative postgres in a gcp bucket
@@ -36,8 +32,6 @@ kind: IAMServiceAccount
 metadata:
   name: sops-kms
   namespace: cnrm-system
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   displayName: sops-kms
   description: To decrypt secrets within flux kustomize controller
@@ -47,8 +41,6 @@ kind: IAMServiceAccount
 metadata:
   name: server-deployment
   namespace: cnrm-system
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: merge
 spec:
   displayName: server-deployment
   description: To assign cloud permissions for server deployment in GKE

--- a/k8s/cnrm-system/context.yaml
+++ b/k8s/cnrm-system/context.yaml
@@ -4,4 +4,6 @@ metadata:
   # you can only have one ConfigConnectorContext per namespace
   name: configconnectorcontext.core.cnrm.cloud.google.com
   namespace: cnrm-system
-spec: {}
+spec:
+  stateIntoSpec: Absent
+


### PR DESCRIPTION
- Set `stateIntoSpec` to `absent` in ConfigConnectorContext as [recommended in the docs](https://cloud.google.com/config-connector/docs/how-to/install-manually#addon-configuring).
  Setting `absent` implies that KCC will skip populating unspecified fields into spec. I suspect this was the primary reason behind those flux spams about `ArtifactRegistryRepository/cnrm-system/hopic-k8s-images configured` in the slack channel.
- Remove manually added `state-into-spec` annotation for all resources except `ComputeAddress` due to [this](https://cloud.google.com/config-connector/docs/concepts/ignore-unspecified-fields#when_to_avoid_cnrmcloudgooglecomstate-into-spec_absent).

Relates to #227 