### PR TITLE
fix: Flux commit message template

### DIFF
--- a/k8s/server/overlays/ephemeral/sync-template.yaml
+++ b/k8s/server/overlays/ephemeral/sync-template.yaml
@@ -118,6 +118,6 @@ spec:
       author:
         name: fluxbot
         email: fluxcd@users.noreply.github.com
-      messageTemplate: "[ci skip] {{range .Changed.Images}}{{println .}}{{end}}"
+      messageTemplate: "[ci skip] {{range .Changed.Changes}} {{println .NewValue}}{{end}}"
     push:
       branch: ${BRANCH_NAME}

--- a/k8s/server/overlays/prod/sync.yaml
+++ b/k8s/server/overlays/prod/sync.yaml
@@ -93,6 +93,6 @@ spec:
       author:
         name: fluxbot
         email: fluxcd@users.noreply.github.com
-      messageTemplate: "[ci skip] {{range .Updated.Images}}{{println .}}{{end}}"
+      messageTemplate: "[ci skip] {{range .Changed.Changes}} {{println .NewValue}}{{end}}"
     push:
       branch: "prod"


### PR DESCRIPTION
- Update Flux commit message template.

As per the [release notes](https://github.com/fluxcd/flux2/releases), `Updated` data template will be deprecated soon. I took a first pass at this in https://github.com/PHACDataHub/cpho-phase2/pull/313, however, seems like it wasn't that simple and lead to 18af29e7b0c52e60af168ab72497de741265c81a.