### PR TITLE
fix: raise axes failure limit to 100 (rather than 3)

### DIFF
--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -87,6 +87,9 @@ from phac_aspc.django.settings.utils import (
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = config("SECRET_KEY")
 
+# this is largely irrelevant because everyone is logging in via SSO
+AXES_FAILURE_LIMIT = config("MAX_LOGIN_ATTEMPTS", default=100, cast=int)
+
 ALLOWED_HOSTS = config("ALLOWED_HOSTS", cast=Csv())
 
 # Additional CORS allowed and CSRF trusted origins should be empty until if/when the app


### PR DESCRIPTION
Someone (*cough Todd cough*) just jammed up the login page for anyone on the VPN because they hit 3 failed attempts and the only fix is to manually delete axes records using CLI (or admin if you're already logged in)

We did something like this for ITAP. I don't remember what we set it to, but we haven't had a problem since. All logins can only be done via SSO so we don't have to worry about anyone trying 100 logins per day or whatever. 