### PR TITLE
feat: Add ephemeral environment django5

### DIFF
--- a/k8s/server/ephemeral-instances/django5-sync.yaml
+++ b/k8s/server/ephemeral-instances/django5-sync.yaml
@@ -1,0 +1,123 @@
+# This manifest is only meant to be used as a template for defining sync configurations
+# in ./k8s/server/ephemeral-instances/ directory. The django5 must be subsituted
+# with the appropriate branch name.
+
+# It should be not applied directly to the cluster
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: django5
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  ref:
+    branch: django5
+  secretRef:
+    name: flux-system
+  url: ssh://git@github.com/PHACDataHub/cpho-phase2
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: django5-infra
+  namespace: flux-system
+spec:
+  path: ./k8s/server/overlays/ephemeral/infrastructure
+  interval: 2m0s
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: django5
+  wait: true
+  dependsOn:
+    - name: ephemeral-instances
+  postBuild:
+    substitute:
+      BRANCH_NAME: django5
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: django5-postgres
+  namespace: flux-system
+spec:
+  path: ./k8s/server/overlays/ephemeral/postgres
+  interval: 2m0s
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: django5
+  wait: true
+  dependsOn:
+    - name: django5-infra
+  postBuild:
+    substitute:
+      BRANCH_NAME: django5
+
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: django5-django
+  namespace: flux-system
+spec:
+  interval: 2m0s
+  path: ./k8s/server/overlays/ephemeral/django
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: django5
+  dependsOn:
+    - name: django5-postgres
+  decryption:
+    provider: sops
+  postBuild:
+    substitute:
+      BRANCH_NAME: django5
+---
+# The following manifests are only required if there's a need to enable automated
+# image updates for ephemeral deployments.
+
+# Note that you'll also need to update the policy name in the `$imagepolicy` comment
+# next to spec.template.spec.image in your branch's server deployment located
+# at ./k8s/server/overlays/ephemeral/django/deployment.yaml
+# See https://fluxcd.io/flux/guides/image-update/ for details
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: django5-server
+  namespace: flux-system
+spec:
+  filterTags:
+    extract: $ts
+    pattern: ^django5-[a-fA-F0-9]+-(?P<ts>.*)
+  imageRepositoryRef:
+    name: server
+  policy:
+    numerical:
+      order: asc
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageUpdateAutomation
+metadata:
+  name: django5-cpho-updater
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: django5
+  interval: 5m
+  update:
+    strategy: Setters
+    path: .
+  git:
+    checkout:
+      ref:
+        branch: django5
+    commit:
+      author:
+        name: fluxbot
+        email: fluxcd@users.noreply.github.com
+      messageTemplate: "[ci skip] {{range .Changed.Changes}} {{println .NewValue}}{{end}}"
+    push:
+      branch: django5


### PR DESCRIPTION
I copied the template and replaced the BRANCH_NAME with my targetted branch, `django5`

I need to test that my new branch doesn't mess with logging, because it's using a new version of structlog. I probably don't need much of a database.

A couple of questions,

1. Do I need to go and enable cloud-build, or is that only if I want to update this branch? If I push an update to this branch, it won't deploy anything?  
2. Is it important that my `django5` branch be ahead of prod? 
3. Will a new database be automatically created and migrated?
    - I presume no scripts are run beyond the plain migrate?
4. If I want to SSH in, can I use the server-management-session script ?