### PR TITLE
feat: set enable PDB and deprecate node maintenance window

### DIFF
--- a/k8s/server/base/postgres/pg-cluster.yaml
+++ b/k8s/server/base/postgres/pg-cluster.yaml
@@ -32,9 +32,8 @@ spec:
       pgaudit.log_relation: "on"
       log_statement: "none"
 
-  nodeMaintenanceWindow:
-    inProgress: false
-    reusePVC: false
+  enablePDB: true
+
 
   inheritedMetadata:
     annotations:


### PR DESCRIPTION
Add `enablePDB` option and deprecate `nodeMaintenanceWindow` as per the release notes for [v1.23.0](https://github.com/cloudnative-pg/cloudnative-pg/releases/tag/v1.23.0).