### PR TITLE
chore: enable pdb on pg cluster

### DIFF
--- a/k8s/server/base/postgres/pg-cluster.yaml
+++ b/k8s/server/base/postgres/pg-cluster.yaml
@@ -32,7 +32,7 @@ spec:
       pgaudit.log_relation: "on"
       log_statement: "none"
 
-  enablePDB: false
+  enablePDB: true
 
 
   inheritedMetadata:


### PR DESCRIPTION
Enable PDB on postgres cluster since the gke upgrade has been completed.

Relates to #356.