### PR TITLE
chore: upgrade KCC to v1.120.1

### DIFF
--- a/k8s/configconnector-operator-system/autopilot-configconnector-operator.yaml
+++ b/k8s/configconnector-operator-system/autopilot-configconnector-operator.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.118.2
+    cnrm.cloud.google.com/operator-version: 1.120.1
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: configconnector-operator-system
@@ -11,7 +11,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.118.2
+    cnrm.cloud.google.com/operator-version: 1.120.1
     controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     cnrm.cloud.google.com/operator-system: "true"
@@ -108,6 +108,12 @@ spec:
                 - Absent
                 - Merge
                 type: string
+              version:
+                description: |-
+                  Version specifies the exact addon version to be deployed, eg 1.2.3
+                  Only limited versions are supported; currently we are only supporting
+                  the operator version and the previous minor version.
+                type: string
             required:
             - googleServiceAccount
             type: object
@@ -138,7 +144,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.118.2
+    cnrm.cloud.google.com/operator-version: 1.120.1
     controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     cnrm.cloud.google.com/operator-system: "true"
@@ -290,7 +296,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.118.2
+    cnrm.cloud.google.com/operator-version: 1.120.1
     controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     cnrm.cloud.google.com/operator-system: "true"
@@ -559,7 +565,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.118.2
+    cnrm.cloud.google.com/operator-version: 1.120.1
     controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     cnrm.cloud.google.com/operator-system: "true"
@@ -772,7 +778,92 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.118.2
+    cnrm.cloud.google.com/operator-version: 1.120.1
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: namespacedcontrollerreconcilers.customize.core.cnrm.cloud.google.com
+spec:
+  group: customize.core.cnrm.cloud.google.com
+  names:
+    kind: NamespacedControllerReconciler
+    listKind: NamespacedControllerReconcilerList
+    plural: namespacedcontrollerreconcilers
+    singular: namespacedcontrollerreconciler
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          NamespacedControllerReconciler is the Schema for reconciliation related customization for
+          namespaced config connector controllers.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NamespacedControllerReconciler is the specification of NamespacedControllerReconciler.
+            properties:
+              rateLimit:
+                description: |-
+                  RateLimit configures the token bucket rate limit to the kubernetes client used
+                  by the manager container of the config connector namespaced controller manager.
+                  Please note this rate limit is shared among all the Config Connector resources' requests.
+                  If not specified, the default will be Token Bucket with qps 20, burst 30.
+                properties:
+                  burst:
+                    description: The burst of the token bucket rate limit for all
+                      the requests to the kubernetes client.
+                    type: integer
+                  qps:
+                    description: The QPS of the token bucket rate limit for all the
+                      requests to the kubernetes client.
+                    type: integer
+                type: object
+            type: object
+          status:
+            description: NamespacedControllerReconcilerStatus defines the observed
+              state of NamespacedControllerReconciler.
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              phase:
+                type: string
+            required:
+            - healthy
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.120.1
     controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     cnrm.cloud.google.com/operator-system: "true"
@@ -1019,7 +1110,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.118.2
+    cnrm.cloud.google.com/operator-version: 1.120.1
     controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     cnrm.cloud.google.com/operator-system: "true"
@@ -1234,7 +1325,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.118.2
+    cnrm.cloud.google.com/operator-version: 1.120.1
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: configconnector-operator
@@ -1244,8 +1335,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.118.2
-    cnrm.cloud.google.com/version: 1.118.2
+    cnrm.cloud.google.com/operator-version: 1.120.1
+    cnrm.cloud.google.com/version: 1.120.1
   creationTimestamp: null
   labels:
     cnrm.cloud.google.com/operator-system: "true"
@@ -2034,7 +2125,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.118.2
+    cnrm.cloud.google.com/operator-version: 1.120.1
   creationTimestamp: null
   labels:
     cnrm.cloud.google.com/operator-system: "true"
@@ -2151,6 +2242,7 @@ rules:
   - namespacedcontrollerresources
   - validatingwebhookconfigurationcustomizations
   - mutatingwebhookconfigurationcustomizations
+  - namespacedcontrollerreconcilers
   verbs:
   - create
   - delete
@@ -2166,6 +2258,7 @@ rules:
   - namespacedcontrollerresources/status
   - validatingwebhookconfigurationcustomizations/status
   - mutatingwebhookconfigurationcustomizations/status
+  - namespacedcontrollerreconcilers/status
   verbs:
   - get
   - patch
@@ -2226,7 +2319,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.118.2
+    cnrm.cloud.google.com/operator-version: 1.120.1
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: configconnector-operator-cnrm-viewer-role-binding
@@ -2243,7 +2336,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.118.2
+    cnrm.cloud.google.com/operator-version: 1.120.1
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: configconnector-operator-rolebinding
@@ -2260,7 +2353,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.118.2
+    cnrm.cloud.google.com/operator-version: 1.120.1
   labels:
     cnrm.cloud.google.com/operator-system: "true"
   name: configconnector-operator-service
@@ -2277,7 +2370,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations:
-    cnrm.cloud.google.com/operator-version: 1.118.2
+    cnrm.cloud.google.com/operator-version: 1.120.1
   labels:
     cnrm.cloud.google.com/component: configconnector-operator
     cnrm.cloud.google.com/operator-system: "true"
@@ -2293,7 +2386,7 @@ spec:
   template:
     metadata:
       annotations:
-        cnrm.cloud.google.com/operator-version: 1.118.2
+        cnrm.cloud.google.com/operator-version: 1.120.1
       labels:
         cnrm.cloud.google.com/component: configconnector-operator
         cnrm.cloud.google.com/operator-system: "true"
@@ -2303,7 +2396,7 @@ spec:
         - --local-repo=/configconnector-operator/autopilot-channels
         command:
         - /configconnector-operator/manager
-        image: gcr.io/gke-release/cnrm/operator:a86c7fe
+        image: gcr.io/gke-release/cnrm/operator:3570282
         imagePullPolicy: Always
         name: manager
         resources:


### PR DESCRIPTION
Upgrade KCC to v1.120.1

Release notes: https://github.com/GoogleCloudPlatform/k8s-config-connector/releases/tag/v1.120.1