### PR TITLE
chore: upgrade cert-manager to v1.15.2

### DIFF
--- a/k8s/cert-manager/crds/cert-manager.yaml
+++ b/k8s/cert-manager/crds/cert-manager.yaml
@@ -34,7 +34,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 spec:
   group: cert-manager.io
   names:
@@ -364,7 +364,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 spec:
   group: cert-manager.io
   names:
@@ -1137,7 +1137,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 spec:
   group: acme.cert-manager.io
   names:
@@ -3093,7 +3093,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 spec:
   group: cert-manager.io
   names:
@@ -5523,7 +5523,7 @@ metadata:
     app.kubernetes.io/instance: 'cert-manager'
     app.kubernetes.io/component: "crds"
     # Generated labels
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 spec:
   group: cert-manager.io
   names:
@@ -7952,7 +7952,7 @@ metadata:
     app.kubernetes.io/instance: 'cert-manager'
     app.kubernetes.io/component: "crds"
     # Generated labels
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 spec:
   group: acme.cert-manager.io
   names:
@@ -8218,7 +8218,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 ---
 # Source: cert-manager/templates/serviceaccount.yaml
 apiVersion: v1
@@ -8232,7 +8232,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 ---
 # Source: cert-manager/templates/webhook-serviceaccount.yaml
 apiVersion: v1
@@ -8246,7 +8246,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 ---
 # Source: cert-manager/templates/cainjector-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8258,7 +8258,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
@@ -8290,7 +8290,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["issuers", "issuers/status"]
@@ -8316,7 +8316,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers", "clusterissuers/status"]
@@ -8342,7 +8342,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
@@ -8377,7 +8377,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders", "orders/status"]
@@ -8415,7 +8415,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 rules:
   # Use to update challenge resource status
   - apiGroups: ["acme.cert-manager.io"]
@@ -8475,7 +8475,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests"]
@@ -8512,7 +8512,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
 rules:
   - apiGroups: ["cert-manager.io"]
@@ -8529,7 +8529,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
@@ -8552,7 +8552,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
@@ -8577,7 +8577,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["signers"]
@@ -8599,7 +8599,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 rules:
   - apiGroups: ["certificates.k8s.io"]
     resources: ["certificatesigningrequests"]
@@ -8625,7 +8625,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 rules:
 - apiGroups: ["authorization.k8s.io"]
   resources: ["subjectaccessreviews"]
@@ -8641,7 +8641,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -8661,7 +8661,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -8681,7 +8681,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -8701,7 +8701,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -8721,7 +8721,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -8741,7 +8741,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -8761,7 +8761,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -8781,7 +8781,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -8801,7 +8801,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -8821,7 +8821,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -8844,7 +8844,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 rules:
   # Used for leader election by the controller
   # cert-manager-cainjector-leader-election is used by the CertificateBased injector controller
@@ -8870,7 +8870,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
@@ -8891,7 +8891,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -8916,7 +8916,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -8939,7 +8939,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -8961,7 +8961,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -8983,7 +8983,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 spec:
   type: ClusterIP
   ports:
@@ -9007,7 +9007,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 spec:
   type: ClusterIP
   ports:
@@ -9031,7 +9031,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 spec:
   replicas: 1
   selector:
@@ -9046,7 +9046,7 @@ spec:
         app.kubernetes.io/name: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "cainjector"
-        app.kubernetes.io/version: "v1.15.0"
+        app.kubernetes.io/version: "v1.15.2"
     spec:
       serviceAccountName: cert-manager-cainjector
       enableServiceLinks: false
@@ -9056,7 +9056,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-cainjector
-          image: "quay.io/jetstack/cert-manager-cainjector:v1.15.0"
+          image: "quay.io/jetstack/cert-manager-cainjector:v1.15.2"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -9086,7 +9086,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 spec:
   replicas: 1
   selector:
@@ -9101,7 +9101,7 @@ spec:
         app.kubernetes.io/name: cert-manager
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "controller"
-        app.kubernetes.io/version: "v1.15.0"
+        app.kubernetes.io/version: "v1.15.2"
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -9115,13 +9115,13 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-controller
-          image: "quay.io/jetstack/cert-manager-controller:v1.15.0"
+          image: "quay.io/jetstack/cert-manager-controller:v1.15.2"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
           - --cluster-resource-namespace=$(POD_NAMESPACE)
           - --leader-election-namespace=kube-system
-          - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.15.0
+          - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.15.2
           - --max-concurrent-challenges=60
           ports:
           - containerPort: 9402
@@ -9168,7 +9168,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
 spec:
   replicas: 1
   selector:
@@ -9183,7 +9183,7 @@ spec:
         app.kubernetes.io/name: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "webhook"
-        app.kubernetes.io/version: "v1.15.0"
+        app.kubernetes.io/version: "v1.15.2"
     spec:
       serviceAccountName: cert-manager-webhook
       enableServiceLinks: false
@@ -9193,7 +9193,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-webhook
-          image: "quay.io/jetstack/cert-manager-webhook:v1.15.0"
+          image: "quay.io/jetstack/cert-manager-webhook:v1.15.2"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -9203,7 +9203,7 @@ spec:
           - --dynamic-serving-dns-names=cert-manager-webhook
           - --dynamic-serving-dns-names=cert-manager-webhook.$(POD_NAMESPACE)
           - --dynamic-serving-dns-names=cert-manager-webhook.$(POD_NAMESPACE).svc
-          
+
           ports:
           - name: https
             protocol: TCP
@@ -9274,7 +9274,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
   annotations:
     cert-manager.io/inject-ca-from-secret: "cert-manager/cert-manager-webhook-ca"
 webhooks:
@@ -9313,7 +9313,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.15.0"
+    app.kubernetes.io/version: "v1.15.2"
   annotations:
     cert-manager.io/inject-ca-from-secret: "cert-manager/cert-manager-webhook-ca"
 webhooks:


### PR DESCRIPTION
Upgrade cert-manager to v1.15.2

Release notes: https://github.com/cert-manager/cert-manager/releases/tag/v1.15.2