### PR TITLE
fix: architecture diagram logos

### DIFF
--- a/architecture-diagram/README.md
+++ b/architecture-diagram/README.md
@@ -22,7 +22,7 @@ To update the svg, cd in to `./architecture-diagram` and run `d2 --layout dagre 
 
 ### Kubernetes
 
-![Current k8s architecture](architecture-k8s.svg)
+![Current k8s architecture](architecture-k8s.png)
 
 ### Network
 

--- a/architecture-diagram/architecture-k8s.d2
+++ b/architecture-diagram/architecture-k8s.d2
@@ -9,7 +9,7 @@ unauthed-traffic: Unauthenticated\napp traffic {
 }
 
 active-directory: Health Canada's\nAzure Active Directory\nsign in page {
-  icon: https://raw.githubusercontent.com/PHACDataHub/cpho-phase2/main/architecture-diagram/icons/general/Azure-Active-Directory.svg
+  icon: ./icons/general/Azure-Active-Directory.svg
   shape: image
 }
 

--- a/architecture-diagram/architecture-k8s.d2
+++ b/architecture-diagram/architecture-k8s.d2
@@ -9,7 +9,7 @@ unauthed-traffic: Unauthenticated\napp traffic {
 }
 
 active-directory: Health Canada's\nAzure Active Directory\nsign in page {
-  icon: ./icons/general/Azure-Active-Directory.svg
+  icon: https://raw.githubusercontent.com/PHACDataHub/cpho-phase2/main/architecture-diagram/icons/general/Azure-Active-Directory.svg
   shape: image
 }
 

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -274,7 +274,7 @@ This deployment architecture is built on top of the [node-microservices-demo](ht
 >  - Blue: CI/CD
 >  - Sky Blue: Observability
 
-![Current k8s architecture](../architecture-diagram/architecture-k8s.svg)
+![Current k8s architecture](../architecture-diagram/architecture-k8s.png)
 
 > See `./architecture-diagram/README.md` at the root of this repository for other diagrams.
 


### PR DESCRIPTION
For some reason the architecture diagram logos weren't being rendered correctly in README.md, this PR adds a `png` for the diagram and updates any occurrences of `svg` to `png`.