### PR TITLE
fix: approved data in infobase export

### DIFF
--- a/server/cpho/views/infobase_export.py
+++ b/server/cpho/views/infobase_export.py
@@ -4,6 +4,7 @@ from django.utils.functional import cached_property
 from django.views import View
 
 import openpyxl
+from data_fetcher import cache_within_request
 from phac_aspc.django.excel import (
     AbstractExportView,
     AbstractSheetWriter,
@@ -15,112 +16,127 @@ from phac_aspc.django.excel import (
 )
 from phac_aspc.rules import test_rule
 
-from cpho.models import Benchmarking, Indicator, IndicatorDatum, TrendAnalysis
+from cpho.models import (
+    Benchmarking,
+    BenchmarkingHistory,
+    Indicator,
+    IndicatorDatum,
+    IndicatorDatumHistory,
+    IndicatorHistory,
+    TrendAnalysis,
+    TrendAnalysisHistory,
+)
 from cpho.util import get
 
 indicator_columns = [
-    ModelColumn(Indicator, "id"),
-    ModelColumn(Indicator, "name"),
-    ModelColumn(Indicator, "name_fr"),
-    ChoiceColumn(Indicator, "category"),
-    ChoiceColumn(Indicator, "topic"),
-    ModelColumn(Indicator, "detailed_indicator"),
-    ModelColumn(Indicator, "detailed_indicator_fr"),
-    ModelColumn(Indicator, "sub_indicator_measurement"),
-    ModelColumn(Indicator, "sub_indicator_measurement_fr"),
-    ModelColumn(Indicator, "measure_text"),
-    ModelColumn(Indicator, "measure_text_fr"),
-    ModelColumn(Indicator, "title_overall"),
-    ModelColumn(Indicator, "title_overall_fr"),
-    ModelColumn(Indicator, "table_title_overall"),
-    ModelColumn(Indicator, "table_title_overall_fr"),
-    ModelColumn(Indicator, "impact_text"),
-    ModelColumn(Indicator, "impact_text_fr"),
-    ModelColumn(Indicator, "general_footnotes"),
-    ModelColumn(Indicator, "general_footnotes_fr"),
-    ModelColumn(Indicator, "main_source_english"),
-    ModelColumn(Indicator, "main_source_fr"),
-    ModelColumn(Indicator, "other_relevant_sources_english"),
-    ModelColumn(Indicator, "other_relevant_sources_fr"),
-    ModelColumn(Indicator, "title_sex"),
-    ModelColumn(Indicator, "title_sex_fr"),
-    ModelColumn(Indicator, "table_title_sex"),
-    ModelColumn(Indicator, "table_title_sex_fr"),
-    ModelColumn(Indicator, "title_age"),
-    ModelColumn(Indicator, "title_age_fr"),
-    ModelColumn(Indicator, "table_title_age"),
-    ModelColumn(Indicator, "table_title_age_fr"),
-    ModelColumn(Indicator, "title_province_territory"),
-    ModelColumn(Indicator, "title_province_territory_fr"),
-    ModelColumn(Indicator, "table_title_province_territory"),
-    ModelColumn(Indicator, "table_title_province_territory_fr"),
-    ModelColumn(Indicator, "pt_dynamic_text"),
-    ModelColumn(Indicator, "pt_dynamic_text_fr"),
-    ModelColumn(Indicator, "title_living_arrangement"),
-    ModelColumn(Indicator, "title_living_arrangement_fr"),
-    ModelColumn(Indicator, "table_title_living_arrangement"),
-    ModelColumn(Indicator, "table_title_living_arrangement_fr"),
-    ModelColumn(Indicator, "title_education_household"),
-    ModelColumn(Indicator, "title_education_household_fr"),
-    ModelColumn(Indicator, "table_title_education_household"),
-    ModelColumn(Indicator, "table_title_education_household_fr"),
-    ModelColumn(Indicator, "title_income_quintiles"),
-    ModelColumn(Indicator, "title_income_quintiles_fr"),
-    ModelColumn(Indicator, "table_title_income_quintiles"),
-    ModelColumn(Indicator, "table_title_income_quintiles_fr"),
-    ModelColumn(Indicator, "title_trend"),
-    ModelColumn(Indicator, "title_trend_fr"),
-    ModelColumn(Indicator, "table_title_trend"),
-    ModelColumn(Indicator, "table_title_trend_fr"),
-    ModelColumn(Indicator, "visual_description_trend"),
-    ModelColumn(Indicator, "visual_description_trend_fr"),
-    ModelColumn(Indicator, "x_axis_trend"),
-    ModelColumn(Indicator, "x_axis_trend_fr"),
-    ModelColumn(Indicator, "y_axis_trend"),
-    ModelColumn(Indicator, "y_axis_trend_fr"),
-    ModelColumn(Indicator, "trend_footnotes"),
-    ModelColumn(Indicator, "trend_footnotes_fr"),
-    ModelColumn(Indicator, "title_benchmark"),
-    ModelColumn(Indicator, "title_benchmark_fr"),
-    ModelColumn(Indicator, "table_title_benchmark"),
-    ModelColumn(Indicator, "table_title_benchmark_fr"),
-    ModelColumn(Indicator, "x_axis_benchmark"),
-    ModelColumn(Indicator, "x_axis_benchmark_fr"),
-    ModelColumn(Indicator, "benchmarking_dynamic_text"),
-    ModelColumn(Indicator, "benchmarking_dynamic_text_fr"),
-    ModelColumn(Indicator, "benchmarking_footnotes"),
-    ModelColumn(Indicator, "benchmarking_footnotes_fr"),
-    ModelColumn(Indicator, "benchmarking_sources_english"),
-    ModelColumn(Indicator, "benchmarking_sources_fr"),
+    CustomColumn("id", lambda x: x.eternal_id),
+    ModelColumn(IndicatorHistory, "name"),
+    ModelColumn(IndicatorHistory, "name_fr"),
+    ChoiceColumn(IndicatorHistory, "category"),
+    ChoiceColumn(IndicatorHistory, "topic"),
+    ModelColumn(IndicatorHistory, "detailed_indicator"),
+    ModelColumn(IndicatorHistory, "detailed_indicator_fr"),
+    ModelColumn(IndicatorHistory, "sub_indicator_measurement"),
+    ModelColumn(IndicatorHistory, "sub_indicator_measurement_fr"),
+    ModelColumn(IndicatorHistory, "measure_text"),
+    ModelColumn(IndicatorHistory, "measure_text_fr"),
+    ModelColumn(IndicatorHistory, "title_overall"),
+    ModelColumn(IndicatorHistory, "title_overall_fr"),
+    ModelColumn(IndicatorHistory, "table_title_overall"),
+    ModelColumn(IndicatorHistory, "table_title_overall_fr"),
+    ModelColumn(IndicatorHistory, "impact_text"),
+    ModelColumn(IndicatorHistory, "impact_text_fr"),
+    ModelColumn(IndicatorHistory, "general_footnotes"),
+    ModelColumn(IndicatorHistory, "general_footnotes_fr"),
+    ModelColumn(IndicatorHistory, "main_source_english"),
+    ModelColumn(IndicatorHistory, "main_source_fr"),
+    ModelColumn(IndicatorHistory, "other_relevant_sources_english"),
+    ModelColumn(IndicatorHistory, "other_relevant_sources_fr"),
+    ModelColumn(IndicatorHistory, "title_sex"),
+    ModelColumn(IndicatorHistory, "title_sex_fr"),
+    ModelColumn(IndicatorHistory, "table_title_sex"),
+    ModelColumn(IndicatorHistory, "table_title_sex_fr"),
+    ModelColumn(IndicatorHistory, "title_age"),
+    ModelColumn(IndicatorHistory, "title_age_fr"),
+    ModelColumn(IndicatorHistory, "table_title_age"),
+    ModelColumn(IndicatorHistory, "table_title_age_fr"),
+    ModelColumn(IndicatorHistory, "title_province_territory"),
+    ModelColumn(IndicatorHistory, "title_province_territory_fr"),
+    ModelColumn(IndicatorHistory, "table_title_province_territory"),
+    ModelColumn(IndicatorHistory, "table_title_province_territory_fr"),
+    ModelColumn(IndicatorHistory, "pt_dynamic_text"),
+    ModelColumn(IndicatorHistory, "pt_dynamic_text_fr"),
+    ModelColumn(IndicatorHistory, "title_living_arrangement"),
+    ModelColumn(IndicatorHistory, "title_living_arrangement_fr"),
+    ModelColumn(IndicatorHistory, "table_title_living_arrangement"),
+    ModelColumn(IndicatorHistory, "table_title_living_arrangement_fr"),
+    ModelColumn(IndicatorHistory, "title_education_household"),
+    ModelColumn(IndicatorHistory, "title_education_household_fr"),
+    ModelColumn(IndicatorHistory, "table_title_education_household"),
+    ModelColumn(IndicatorHistory, "table_title_education_household_fr"),
+    ModelColumn(IndicatorHistory, "title_income_quintiles"),
+    ModelColumn(IndicatorHistory, "title_income_quintiles_fr"),
+    ModelColumn(IndicatorHistory, "table_title_income_quintiles"),
+    ModelColumn(IndicatorHistory, "table_title_income_quintiles_fr"),
+    ModelColumn(IndicatorHistory, "title_trend"),
+    ModelColumn(IndicatorHistory, "title_trend_fr"),
+    ModelColumn(IndicatorHistory, "table_title_trend"),
+    ModelColumn(IndicatorHistory, "table_title_trend_fr"),
+    ModelColumn(IndicatorHistory, "visual_description_trend"),
+    ModelColumn(IndicatorHistory, "visual_description_trend_fr"),
+    ModelColumn(IndicatorHistory, "x_axis_trend"),
+    ModelColumn(IndicatorHistory, "x_axis_trend_fr"),
+    ModelColumn(IndicatorHistory, "y_axis_trend"),
+    ModelColumn(IndicatorHistory, "y_axis_trend_fr"),
+    ModelColumn(IndicatorHistory, "trend_footnotes"),
+    ModelColumn(IndicatorHistory, "trend_footnotes_fr"),
+    ModelColumn(IndicatorHistory, "title_benchmark"),
+    ModelColumn(IndicatorHistory, "title_benchmark_fr"),
+    ModelColumn(IndicatorHistory, "table_title_benchmark"),
+    ModelColumn(IndicatorHistory, "table_title_benchmark_fr"),
+    ModelColumn(IndicatorHistory, "x_axis_benchmark"),
+    ModelColumn(IndicatorHistory, "x_axis_benchmark_fr"),
+    ModelColumn(IndicatorHistory, "benchmarking_dynamic_text"),
+    ModelColumn(IndicatorHistory, "benchmarking_dynamic_text_fr"),
+    ModelColumn(IndicatorHistory, "benchmarking_footnotes"),
+    ModelColumn(IndicatorHistory, "benchmarking_footnotes_fr"),
+    ModelColumn(IndicatorHistory, "benchmarking_sources_english"),
+    ModelColumn(IndicatorHistory, "benchmarking_sources_fr"),
     # quintiles
-    ModelColumn(Indicator, "g1"),
-    ModelColumn(Indicator, "g2_lower"),
-    ModelColumn(Indicator, "g2_upper"),
-    ModelColumn(Indicator, "g3_lower"),
-    ModelColumn(Indicator, "g3_upper"),
-    ModelColumn(Indicator, "g4_lower"),
-    ModelColumn(Indicator, "g4_upper"),
-    ModelColumn(Indicator, "g5"),
+    ModelColumn(IndicatorHistory, "g1"),
+    ModelColumn(IndicatorHistory, "g2_lower"),
+    ModelColumn(IndicatorHistory, "g2_upper"),
+    ModelColumn(IndicatorHistory, "g3_lower"),
+    ModelColumn(IndicatorHistory, "g3_upper"),
+    ModelColumn(IndicatorHistory, "g4_lower"),
+    ModelColumn(IndicatorHistory, "g4_upper"),
+    ModelColumn(IndicatorHistory, "g5"),
 ]
 
-
-class IndicatorSheetWriter(ModelToSheetWriter):
-    sheet_name = "indicator"
-    columns = indicator_columns
-    queryset = Indicator.objects.all().order_by("name")
-
-
 indicator_data_columns = [
-    ModelColumn(IndicatorDatum, "id"),
-    CustomColumn("indicator_id", lambda x: x.indicator_id),
-    # indicator columns useful to help identify??
-    CustomColumn("indicator name", lambda x: x.indicator.name),
+    CustomColumn("id", lambda x: x.eternal_id),
     CustomColumn(
-        "detailed indicator", lambda x: x.indicator.detailed_indicator
+        "indicator_id",
+        lambda x: x.indicator_id,
+    ),
+    # indicator columns useful to help identify??
+    CustomColumn(
+        "indicator name",
+        lambda x: ExportHelpers.get_submitted_indicator_by_eternal_id(
+            x.indicator_id
+        ).name,
+    ),
+    CustomColumn(
+        "detailed indicator",
+        lambda x: ExportHelpers.get_submitted_indicator_by_eternal_id(
+            x.indicator_id
+        ).detailed_indicator,
     ),
     CustomColumn(
         "sub indicator measurement",
-        lambda x: x.indicator.sub_indicator_measurement,
+        lambda x: ExportHelpers.get_submitted_indicator_by_eternal_id(
+            x.indicator_id
+        ).sub_indicator_measurement,
     ),
     # denormalized periods, they'll probably only use year
     CustomColumn("year", lambda x: x.period.year),
@@ -145,92 +161,213 @@ indicator_data_columns = [
         "literal_dimension_val", lambda x: x.literal_dimension_val or ""
     ),
     # value columns
-    ChoiceColumn(IndicatorDatum, "data_quality"),
-    ChoiceColumn(IndicatorDatum, "reason_for_null"),
-    ModelColumn(IndicatorDatum, "value"),
-    ModelColumn(IndicatorDatum, "value_lower_bound"),
-    ModelColumn(IndicatorDatum, "value_upper_bound"),
-    ChoiceColumn(IndicatorDatum, "value_unit"),
-    ChoiceColumn(IndicatorDatum, "value_displayed"),
-    ModelColumn(IndicatorDatum, "single_year_timeframe"),
-    ModelColumn(IndicatorDatum, "multi_year_timeframe"),
-    ModelColumn(IndicatorDatum, "arrow_flag"),
+    ChoiceColumn(IndicatorDatumHistory, "data_quality"),
+    ChoiceColumn(IndicatorDatumHistory, "reason_for_null"),
+    ModelColumn(IndicatorDatumHistory, "value"),
+    ModelColumn(IndicatorDatumHistory, "value_lower_bound"),
+    ModelColumn(IndicatorDatumHistory, "value_upper_bound"),
+    ChoiceColumn(IndicatorDatumHistory, "value_unit"),
+    ChoiceColumn(IndicatorDatumHistory, "value_displayed"),
+    ModelColumn(IndicatorDatumHistory, "single_year_timeframe"),
+    ModelColumn(IndicatorDatumHistory, "multi_year_timeframe"),
+    ModelColumn(IndicatorDatumHistory, "arrow_flag"),
 ]
+
+benchmarking_columns = [
+    CustomColumn("id", lambda x: x.eternal_id),
+    CustomColumn("indicator_id", lambda x: x.indicator_id),
+    # indicator columns useful to help identify??
+    CustomColumn(
+        "indicator name",
+        lambda x: ExportHelpers.get_submitted_indicator_by_eternal_id(
+            x.indicator_id
+        ).name,
+    ),
+    CustomColumn(
+        "detailed indicator",
+        lambda x: ExportHelpers.get_submitted_indicator_by_eternal_id(
+            x.indicator_id
+        ).detailed_indicator,
+    ),
+    CustomColumn(
+        "sub indicator measurement",
+        lambda x: ExportHelpers.get_submitted_indicator_by_eternal_id(
+            x.indicator_id
+        ).sub_indicator_measurement,
+    ),
+    ChoiceColumn(BenchmarkingHistory, "unit"),
+    CustomColumn(
+        "oecd_country",
+        lambda x: get(x, "oecd_country.name_en"),
+    ),
+    ModelColumn(BenchmarkingHistory, "value"),
+    ModelColumn(BenchmarkingHistory, "year"),
+    ChoiceColumn(BenchmarkingHistory, "comparison_to_oecd_avg"),
+    ChoiceColumn(BenchmarkingHistory, "labels"),
+]
+
+trend_columns = [
+    CustomColumn("id", lambda x: x.eternal_id),
+    CustomColumn("indicator_id", lambda x: x.indicator_id),
+    # indicator columns useful to help identify??
+    CustomColumn(
+        "indicator name",
+        lambda x: ExportHelpers.get_submitted_indicator_by_eternal_id(
+            x.indicator_id
+        ).name,
+    ),
+    CustomColumn(
+        "detailed indicator",
+        lambda x: ExportHelpers.get_submitted_indicator_by_eternal_id(
+            x.indicator_id
+        ).detailed_indicator,
+    ),
+    CustomColumn(
+        "sub indicator measurement",
+        lambda x: ExportHelpers.get_submitted_indicator_by_eternal_id(
+            x.indicator_id
+        ).sub_indicator_measurement,
+    ),
+    ModelColumn(TrendAnalysisHistory, "year"),
+    ModelColumn(TrendAnalysisHistory, "data_point"),
+    ModelColumn(TrendAnalysisHistory, "line_of_best_fit_point"),
+    ModelColumn(TrendAnalysisHistory, "trend_segment"),
+    ChoiceColumn(TrendAnalysisHistory, "trend"),
+    ChoiceColumn(TrendAnalysisHistory, "data_quality"),
+    ChoiceColumn(TrendAnalysisHistory, "unit"),
+]
+
+
+class ExportHelpers:
+    @cache_within_request
+    @staticmethod
+    def get_submitted_indicator_ids():
+        """
+        Returns a list of indicator version ids that have been submitted
+        """
+        indicator_data = (
+            Indicator.objects.all().with_last_submitted_version_id()
+        ).order_by("name")
+        indicator_version_ids = [
+            x.last_submitted_version_id
+            for x in indicator_data
+            if x.last_submitted_version_id is not None
+        ]
+        return indicator_version_ids
+
+    @classmethod
+    @cache_within_request
+    def get_submitted_indicators(cls):
+        """
+        Returns a list of indicator history objects that have been submitted
+        """
+        indicator_version_ids = cls.get_submitted_indicator_ids()
+        return IndicatorHistory.objects.filter(
+            pk__in=indicator_version_ids
+        ).order_by("name")
+
+    @classmethod
+    @cache_within_request
+    def get_submitted_indicator_dict_by_eternal_id(cls):
+        all_submitted_indicators = cls.get_submitted_indicators()
+        return {
+            submitted_indicator.eternal_id: submitted_indicator
+            for submitted_indicator in all_submitted_indicators
+        }
+
+    @classmethod
+    def get_submitted_indicator_by_eternal_id(cls, eternal_id):
+        return cls.get_submitted_indicator_dict_by_eternal_id()[eternal_id]
+
+    @classmethod
+    def get_submitted_data(cls):
+        eternal_ids = [x.eternal_id for x in cls.get_submitted_indicators()]
+        data = IndicatorDatum.objects.filter(
+            indicator_id__in=eternal_ids, is_deleted=False
+        ).with_last_submitted_version_id()
+        version_ids = [
+            x.last_submitted_version_id
+            for x in data
+            if x.last_submitted_version_id is not None
+        ]
+        submitted_data = (
+            IndicatorDatumHistory.objects.filter(pk__in=version_ids)
+            .select_related("period", "dimension_type", "dimension_value")
+            .order_by("indicator_id", "period_id", "dimension_type_id")
+        )
+        return submitted_data
+
+    @classmethod
+    def get_submitted_benchmarking(cls):
+        eternal_ids = [x.eternal_id for x in cls.get_submitted_indicators()]
+        benchmarking_data = Benchmarking.objects.filter(
+            indicator_id__in=eternal_ids, is_deleted=False
+        ).with_last_submitted_version_id()
+        version_ids = [
+            x.last_submitted_version_id
+            for x in benchmarking_data
+            if x.last_submitted_version_id is not None
+        ]
+        submitted_benchmarking = (
+            BenchmarkingHistory.objects.filter(pk__in=version_ids)
+            .select_related("indicator", "oecd_country")
+            .order_by("indicator_id", "labels", "value")
+        )
+        return submitted_benchmarking
+
+    @classmethod
+    def get_submitted_trend_analysis(cls):
+        eternal_ids = [x.eternal_id for x in cls.get_submitted_indicators()]
+        trend_data = TrendAnalysis.objects.filter(
+            indicator_id__in=eternal_ids, is_deleted=False
+        ).with_last_submitted_version_id()
+        version_ids = [
+            x.last_submitted_version_id
+            for x in trend_data
+            if x.last_submitted_version_id is not None
+        ]
+        submitted_trend = (
+            TrendAnalysisHistory.objects.filter(pk__in=version_ids)
+            .select_related("indicator")
+            .order_by("indicator_id", "year")
+        )
+        return submitted_trend
+
+
+class IndicatorSheetWriter(ModelToSheetWriter):
+    sheet_name = "indicator"
+    columns = indicator_columns
+
+    def get_queryset(self):
+        data = ExportHelpers.get_submitted_indicators()
+        return data
 
 
 class IndicatorDatumSheetWriter(ModelToSheetWriter):
     sheet_name = "indicator_data"
-    queryset = (
-        IndicatorDatum.objects.all()
-        .select_related(
-            "indicator", "period", "dimension_type", "dimension_value"
-        )
-        .order_by("indicator_id", "period_id", "dimension_type_id")
-    )
     columns = indicator_data_columns
 
-
-benchmarking_columns = [
-    ModelColumn(IndicatorDatum, "id"),
-    CustomColumn("indicator_id", lambda x: x.indicator_id),
-    # indicator columns useful to help identify??
-    CustomColumn("indicator name", lambda x: x.indicator.name),
-    CustomColumn(
-        "detailed indicator", lambda x: x.indicator.detailed_indicator
-    ),
-    CustomColumn(
-        "sub indicator measurement",
-        lambda x: x.indicator.sub_indicator_measurement,
-    ),
-    ChoiceColumn(Benchmarking, "unit"),
-    ModelColumn(Benchmarking, "oecd_country"),
-    ModelColumn(Benchmarking, "value"),
-    ModelColumn(Benchmarking, "year"),
-    ChoiceColumn(Benchmarking, "comparison_to_oecd_avg"),
-    ChoiceColumn(Benchmarking, "labels"),
-]
+    def get_queryset(self):
+        data = ExportHelpers.get_submitted_data()
+        return data
 
 
 class BenchmarkingSheetWriter(ModelToSheetWriter):
     columns = benchmarking_columns
     sheet_name = "benchmarking"
-    queryset = (
-        Benchmarking.objects.all()
-        .select_related("indicator", "oecd_country")
-        .order_by("indicator_id", "labels", "value")
-    )
 
-
-trend_columns = [
-    ModelColumn(TrendAnalysis, "id"),
-    CustomColumn("indicator_id", lambda x: x.indicator_id),
-    # indicator columns useful to help identify??
-    CustomColumn("indicator name", lambda x: x.indicator.name),
-    CustomColumn(
-        "detailed indicator", lambda x: x.indicator.detailed_indicator
-    ),
-    CustomColumn(
-        "sub indicator measurement",
-        lambda x: x.indicator.sub_indicator_measurement,
-    ),
-    ModelColumn(TrendAnalysis, "year"),
-    ModelColumn(TrendAnalysis, "data_point"),
-    ModelColumn(TrendAnalysis, "line_of_best_fit_point"),
-    ModelColumn(TrendAnalysis, "trend_segment"),
-    ChoiceColumn(TrendAnalysis, "trend"),
-    ChoiceColumn(TrendAnalysis, "data_quality"),
-    ChoiceColumn(TrendAnalysis, "unit"),
-]
+    def get_queryset(self):
+        data = ExportHelpers.get_submitted_benchmarking()
+        return data
 
 
 class TrendSheetWriter(ModelToSheetWriter):
     columns = trend_columns
-    sheet_name = "trend analysis"
-    queryset = (
-        TrendAnalysis.objects.all()
-        .select_related("indicator")
-        .order_by("indicator_id", "year")
-    )
+    sheet_name = "trend"
+
+    def get_queryset(self):
+        data = ExportHelpers.get_submitted_trend_analysis()
+        return data
 
 
 class InfobaseExportView(View):
@@ -239,12 +376,13 @@ class InfobaseExportView(View):
         return openpyxl.Workbook(write_only=True)
 
     def write_indicators(self):
-        # todo: use submitted indicators instead
         writer = IndicatorSheetWriter(workbook=self.workbook)
         writer.write()
 
     def write_indicator_data(self):
-        writer = IndicatorDatumSheetWriter(workbook=self.workbook)
+        writer = IndicatorDatumSheetWriter(
+            workbook=self.workbook,
+        )
         writer.write()
 
     def write_trends(self):
@@ -267,9 +405,9 @@ class InfobaseExportView(View):
         response = HttpResponse(
             headers={"Content-Type": "application/vnd.ms-excel"}
         )
-        response[
-            "Content-Disposition"
-        ] = f"attachment; filename=hopic_infobase_export.xlsx"
+        response["Content-Disposition"] = (
+            f"attachment; filename=hopic_infobase_export.xlsx"
+        )
         self.workbook.save(response)
 
         return response

--- a/server/cpho/views/infobase_export.py
+++ b/server/cpho/views/infobase_export.py
@@ -301,7 +301,9 @@ class ExportHelpers:
     def get_submitted_benchmarking(cls):
         eternal_ids = [x.eternal_id for x in cls.get_submitted_indicators()]
         benchmarking_data = Benchmarking.objects.filter(
-            indicator_id__in=eternal_ids, is_deleted=False
+            # might not be necessary as benchmarking gets submitted with indicator but just in case
+            indicator_id__in=eternal_ids,
+            is_deleted=False,
         ).with_last_submitted_version_id()
         version_ids = [
             x.last_submitted_version_id
@@ -319,7 +321,9 @@ class ExportHelpers:
     def get_submitted_trend_analysis(cls):
         eternal_ids = [x.eternal_id for x in cls.get_submitted_indicators()]
         trend_data = TrendAnalysis.objects.filter(
-            indicator_id__in=eternal_ids, is_deleted=False
+            # might not be necessary as trend gets submitted with indicator but just in case
+            indicator_id__in=eternal_ids,
+            is_deleted=False,
         ).with_last_submitted_version_id()
         version_ids = [
             x.last_submitted_version_id
@@ -405,9 +409,9 @@ class InfobaseExportView(View):
         response = HttpResponse(
             headers={"Content-Type": "application/vnd.ms-excel"}
         )
-        response["Content-Disposition"] = (
-            f"attachment; filename=hopic_infobase_export.xlsx"
-        )
+        response[
+            "Content-Disposition"
+        ] = f"attachment; filename=hopic_infobase_export.xlsx"
         self.workbook.save(response)
 
         return response

--- a/server/tests/test_infobase_export.py
+++ b/server/tests/test_infobase_export.py
@@ -1,5 +1,8 @@
+from io import BytesIO
+
 from django.urls import reverse
 
+import openpyxl
 from phac_aspc.rules import patch_rules
 
 from cpho.model_factories import (
@@ -8,7 +11,20 @@ from cpho.model_factories import (
     IndicatorFactory,
     TrendAnalysisFactory,
 )
-from cpho.models import Benchmarking, Country, TrendAnalysis
+from cpho.models import (
+    Benchmarking,
+    Country,
+    DimensionType,
+    DimensionValue,
+    Indicator,
+    IndicatorDatum,
+    Period,
+    TrendAnalysis,
+)
+from cpho.services import (
+    SubmitIndicatorDataService,
+    SubmitIndicatorMetaDataService,
+)
 
 
 def test_infobase_export(vanilla_user_client):
@@ -59,3 +75,119 @@ def test_infobase_export_queries(
         response = vanilla_user_client.get(url)
         assert response.status_code == 200
         assert response["Content-Type"] == "application/vnd.ms-excel"
+
+
+def get_data_from_worksheet(file, sheet_num):
+    wb = openpyxl.load_workbook(file)
+    ws = wb.worksheets[sheet_num]
+    header_row = [cell.value for cell in ws[1]]
+    data = []
+    for row in ws.iter_rows(min_row=2, values_only=True):
+        data.append(dict(zip(header_row, row)))
+    return data
+
+
+def test_infobase_export_with_approved_data(
+    vanilla_user_client, vanilla_user, django_assert_max_num_queries
+):
+    url = reverse("infobase_export")
+    sex_dim_type = DimensionType.objects.get(code="sex")
+    possible_dimension_value = sex_dim_type.possible_values.all()
+    p = Period.objects.first()
+
+    i1 = IndicatorFactory.create(
+        name="indicator1",
+    )
+    i2 = IndicatorFactory.create(
+        name="indicator2",
+    )
+    male_i1 = IndicatorDatumFactory.create(
+        indicator=i1,
+        period=p,
+        dimension_type=sex_dim_type,
+        dimension_value=possible_dimension_value[0],
+        value=1.1,
+    )
+    female_i1 = IndicatorDatumFactory.create(
+        indicator=i1,
+        period=p,
+        dimension_type=sex_dim_type,
+        dimension_value=possible_dimension_value[1],
+        value=1.2,
+    )
+    male_i2 = IndicatorDatumFactory.create(
+        indicator=i2,
+        period=p,
+        dimension_type=sex_dim_type,
+        dimension_value=possible_dimension_value[0],
+        value=2.1,
+    )
+    female_i2 = IndicatorDatumFactory.create(
+        indicator=i2,
+        period=p,
+        dimension_type=sex_dim_type,
+        dimension_value=possible_dimension_value[1],
+        value=2.2,
+    )
+    i1 = Indicator.objects.get(pk=i1.pk)
+
+    SubmitIndicatorDataService(
+        i1, p, sex_dim_type, "hso", vanilla_user
+    ).perform()
+
+    # Indicator data submitted but Indicator metadata not submitted yet
+    # Export should not include the data
+    with patch_rules(is_admin_or_hso=True), django_assert_max_num_queries(15):
+        response = vanilla_user_client.get(url)
+        assert response.status_code == 200
+        assert response["Content-Type"] == "application/vnd.ms-excel"
+        assert response.content
+        file = BytesIO(response.content)
+        data = get_data_from_worksheet(file, 0)
+        assert len(data) == 0
+
+    # indicator metadata now submitted
+    SubmitIndicatorMetaDataService(i1, "hso", vanilla_user).perform()
+
+    # sex data for i1 should be included in the export
+    with patch_rules(is_admin_or_hso=True), django_assert_max_num_queries(15):
+        response = vanilla_user_client.get(url)
+        assert response.status_code == 200
+        assert response["Content-Type"] == "application/vnd.ms-excel"
+        assert response.content
+        file = BytesIO(response.content)
+
+        # only i1 should be included in the indicator sheet
+        data = get_data_from_worksheet(file, 0)
+        assert len(data) == 1
+        assert data[0]["name"] == "indicator1"
+
+        # only i1 data should be included in the indicator_data sheet
+        data = get_data_from_worksheet(file, 1)
+        assert len(data) == 2
+        for item in data:
+            assert item["indicator name"] == "indicator1"
+
+    # update name of i1
+    i1.name = "indicator1_updated"
+    i1.save()
+
+    # indicator name update but not submitted
+    with patch_rules(is_admin_or_hso=True), django_assert_max_num_queries(15):
+        response = vanilla_user_client.get(url)
+        assert response.status_code == 200
+        assert response["Content-Type"] == "application/vnd.ms-excel"
+        assert response.content
+        file = BytesIO(response.content)
+
+        # only i1 should be included in the indicator sheet
+        data = get_data_from_worksheet(file, 0)
+        assert len(data) == 1
+        # indicator name should not be updated
+        assert data[0]["name"] == "indicator1"
+
+        data = get_data_from_worksheet(file, 1)
+        assert len(data) == 2
+        for item in data:
+            # indicator name should not be updated
+            assert item["indicator name"] == "indicator1"


### PR DESCRIPTION
This PR achieves 3 things:
1. Only Approved data included in infobase export.
2.  If indicator data/ benchmarking or trend is submitted but indicator itself is not submitted, wont export any data related to that indicator
3. if indicator, indicator data, benchmarking, trend all submitted once, but later indicator has unsubmitted changes, in this case export will show the information from the last submitted version of the indicator in all 4 worksheets