### PR TITLE
Revert "chore: update debug-toolbar to support jinja templates"

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4==4.12.0
-django-debug-toolbar==4.4.6
 django-cors-headers==4.4.0
+django-debug-toolbar==4.4.2
 django-data-fetcher==2.2
 django-graphiql-debug-toolbar==0.2.0
 django-extensions==3.2.3


### PR DESCRIPTION
Reverts PHACDataHub/cpho-phase2#357

Wait for https://github.com/flavors/django-graphiql-debug-toolbar/issues/26 to get fixed before re-reverting this