### PR TITLE
fix: add htmx debugging

### DIFF
--- a/server/cpho/jinja2/base.jinja2
+++ b/server/cpho/jinja2/base.jinja2
@@ -24,7 +24,7 @@
     <script src="{{ static('third_party/js/idiomorph.min.js') }}"></script>
     <script src="{{ static('third_party/js/idiomorph-ext.min.js') }}"></script>
     <script src="{{ static('js/tooltip_accessibility.js') }}"></script>
-    {% if debug %}<script src="{{ static('third_party/js/htmx-debug.js') }}"></script>{% endif %}
+    {% if debug %}{{ django_htmx_script() }}{% endif %}
     {% block medias %}{% endblock %}
     {% block extra_scripts_css %}{% endblock %}
   </head>

--- a/server/cpho/jinja_helpers.py
+++ b/server/cpho/jinja_helpers.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from django.utils.translation import activate, get_language
 
 import phac_aspc.django.helpers.templatetags as phac_aspc
+from django_htmx.templatetags.django_htmx import django_htmx_script
 from jinja2 import Environment, pass_context
 from phac_aspc.rules import test_rule
 
@@ -183,6 +184,7 @@ def environment(**options):
             "hasattr": hasattr,
             "len": len,
             "list": list,
+            "django_htmx_script": django_htmx_script,
             "url": reverse,
             "url_to_other_lang": url_to_other_lang,
             "get_lang_code": get_lang_code,

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -4,6 +4,7 @@ django-debug-toolbar==4.4.2
 django-data-fetcher==2.2
 django-graphiql-debug-toolbar==0.2.0
 django-extensions==3.2.3
+django-htmx==1.21.0
 django-htmx-autocomplete==1.0.5
 django-phac_aspc-helpers==3.1.1
 Django==5.0.9

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -193,6 +193,7 @@ INSTALLED_APPS = configure_apps(
         ),
         "rules.apps.AutodiscoverRulesConfig",
         "ckeditor",
+        "django_htmx",
     ]
 )
 
@@ -218,6 +219,7 @@ MIDDLEWARE = configure_middleware(
         "data_fetcher.middleware.GlobalRequestMiddleware",
         "versionator.middleware.WhodidMiddleware",
         "server.middleware.MustBeLoggedInMiddleware",
+        "django_htmx.middleware.HtmxMiddleware",
     ]
 )
 


### PR DESCRIPTION
Forces the yellow django error page on failed htmx requests, doing this in all the django projects.

Probably not super useful in this project, we only have one htmx request in the upload feature