### PR TITLE
fix: add conditional banner when RIBBON_ENV is set to 'dev' or 'production'

### DIFF
--- a/server/.env.dev-public
+++ b/server/.env.dev-public
@@ -34,3 +34,6 @@ FORCE_WHITENOISE_PROD_BEHAVIOUR=False
 
 # Not applicable in prod, where telemetry always goes to GCP
 OUTPUT_TELEMETRY_TO_CONSOLE=False
+
+
+RIBBON_ENV=dev

--- a/server/cpho/jinja2/base.jinja2
+++ b/server/cpho/jinja2/base.jinja2
@@ -30,6 +30,8 @@
     {% block extra_scripts_css %}{% endblock %}
   </head>
   <body hx-ext="morph">
+    <a class="visually-hidden-focusable" href="#main-content" id="skip-link">{{ tm("skip_to_main") }}</a>
+    {% if RIBBON_ENV %}<div class="corner-ribbon d-print-none {{ RIBBON_ENV }}">{{ RIBBON_ENV }}</div>{% endif %}
     {{ phac_aspc.phac_aspc_wet_session_timeout_dialog(dict(request=request) , 'logout') }}
     <div id="modal-moint-point"></div>
     <script>

--- a/server/cpho/jinja_helpers.py
+++ b/server/cpho/jinja_helpers.py
@@ -214,6 +214,7 @@ def environment(**options):
             "ENABLE_LEGACY_LOG_IN": config(
                 "ENABLE_LEGACY_LOG_IN", cast=bool, default=False
             ),
+            "RIBBON_ENV": config("RIBBON_ENV", default=""),
         }
     )
     env.filters["quote"] = lambda x: quote(str(x))

--- a/server/static/cpho.css
+++ b/server/static/cpho.css
@@ -171,3 +171,42 @@ span.new-ind-tag {
     outline-style: solid;
     outline-width: 0.25rem;
 }
+
+
+
+/* Corner ribbons */
+
+.corner-ribbon {
+    width: 210px;
+    padding: 7px 10px;
+    position: absolute;
+    text-align: center;
+    color: #fff;
+    position: fixed;
+    top: 13px;
+    left: -72px;
+    transform: rotate(-45deg);
+    z-index: 100;
+    text-transform: uppercase;
+    font-family: Helvetica, Arial, sans-serif;
+    font-weight: 700;
+    opacity: 0.75;
+    display: none;
+    z-index: 10000;
+}
+
+.corner-ribbon.dev {
+    background: var(--bs-green);
+    display: block;
+    font-size: 1.2em;
+}
+
+.corner-ribbon.production {
+    background: var(--bs-orange);
+    display: block;
+    opacity: 0.5;
+    font-size: 0.8em;
+    top: 25px;
+    left: -60px;
+    color: black;
+}


### PR DESCRIPTION
To show the dev (green) or production (red) banner, we just need to add a RIBBON_ENV env-var set to "dev" or "production"